### PR TITLE
feat: Workflow state badge + header size bump (M004/S01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Action button SVGs increased from 14×14 to 18×18
 - Responsive breakpoints updated for new sizing
 
-### Previous
-
+### Added (previous)
 - Session history panel — browse and resume previous conversations (M002/S01)
 - History button in header toolbar with clock icon
 - Click a previous session to switch — chat loads full conversation history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Added
+- GSD workflow state badge in header — shows active milestone/slice/task and phase (M004/S01)
+- Auto-mode indicator (⚡ Auto, ▸ Next, ⏸ Paused) in workflow badge
+- Phase-specific badge colors: blue (active), green (auto/complete), yellow (paused), red (blocked)
+- STATE.md parser reads workflow state from disk, refreshes on agent turns and every 30s
+
+### Changed
+- Header components ~30% larger: badges (12px font, 28px height), buttons (12px font, 16px icons), brand (18px logo, 15px title)
+- Header min-height increased from 36px to 46px
+- Action button SVGs increased from 14×14 to 18×18
+- Responsive breakpoints updated for new sizing
+
+### Previous
+
 - Session history panel — browse and resume previous conversations (M002/S01)
 - History button in header toolbar with clock icon
 - Click a previous session to switch — chat loads full conversation history

--- a/src/extension/state-parser.ts
+++ b/src/extension/state-parser.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import type { WorkflowStateRef } from "../shared/types";
 
 // ============================================================
 // GSD STATE.md Parser
@@ -7,12 +8,9 @@ import * as path from "path";
 // ============================================================
 
 export interface GsdWorkflowState {
-  /** Active milestone ID and title, or null */
-  milestone: { id: string; title: string } | null;
-  /** Active slice ID and title, or null */
-  slice: { id: string; title: string } | null;
-  /** Active task ID and title, or null */
-  task: { id: string; title: string } | null;
+  milestone: WorkflowStateRef | null;
+  slice: WorkflowStateRef | null;
+  task: WorkflowStateRef | null;
   /** Current phase */
   phase: string;
   /** Auto-mode status: "auto", "next", "paused", or null (not in auto-mode) */

--- a/src/extension/state-parser.ts
+++ b/src/extension/state-parser.ts
@@ -1,0 +1,87 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// ============================================================
+// GSD STATE.md Parser
+// Reads `.gsd/STATE.md` and extracts workflow state for the header badge.
+// ============================================================
+
+export interface GsdWorkflowState {
+  /** Active milestone ID and title, or null */
+  milestone: { id: string; title: string } | null;
+  /** Active slice ID and title, or null */
+  slice: { id: string; title: string } | null;
+  /** Active task ID and title, or null */
+  task: { id: string; title: string } | null;
+  /** Current phase */
+  phase: string;
+  /** Auto-mode status: "auto", "next", "paused", or null (not in auto-mode) */
+  autoMode: string | null;
+}
+
+/**
+ * Parse the active ref line from STATE.md.
+ * Format: `**Active Milestone:** M004 — Title` or `**Active Milestone:** (none)`
+ * Also handles: `M004 — Title ✓ COMPLETE`
+ */
+function parseActiveRef(content: string, label: string): { id: string; title: string } | null {
+  // Match: **Active <Label>:** <id> — <title> [optional ✓ COMPLETE]
+  const re = new RegExp(`\\*\\*Active ${label}:\\*\\*\\s*(.+)`, "i");
+  const match = content.match(re);
+  if (!match) return null;
+
+  const value = match[1].trim();
+  if (value === "(none)" || value === "—" || !value) return null;
+
+  // Try to parse "ID — Title" or "ID: Title" or just "ID"
+  const dashMatch = value.match(/^(\S+)\s*[—–-]\s*(.+?)(?:\s*✓.*)?$/);
+  if (dashMatch) {
+    return { id: dashMatch[1], title: dashMatch[2].trim() };
+  }
+
+  const colonMatch = value.match(/^(\S+):\s*(.+?)(?:\s*✓.*)?$/);
+  if (colonMatch) {
+    return { id: colonMatch[1], title: colonMatch[2].trim() };
+  }
+
+  // Just an ID with no title
+  return { id: value.replace(/\s*✓.*$/, "").trim(), title: "" };
+}
+
+/**
+ * Parse the phase line from STATE.md.
+ * Format: `**Phase:** Executing` or `**Phase:** Complete`
+ */
+function parsePhase(content: string): string {
+  const match = content.match(/\*\*Phase:\*\*\s*(.+)/i);
+  if (!match) return "unknown";
+  return match[1].trim().toLowerCase();
+}
+
+/**
+ * Read and parse `.gsd/STATE.md` from the given workspace root.
+ * Returns null if `.gsd/STATE.md` doesn't exist or can't be parsed.
+ */
+export async function parseGsdWorkflowState(cwd: string): Promise<GsdWorkflowState | null> {
+  const statePath = path.join(cwd, ".gsd", "STATE.md");
+
+  try {
+    const content = await fs.promises.readFile(statePath, "utf-8");
+
+    const milestone = parseActiveRef(content, "Milestone");
+    const slice = parseActiveRef(content, "Slice");
+    const task = parseActiveRef(content, "Task");
+    const phase = parsePhase(content);
+
+    return {
+      milestone,
+      slice,
+      task,
+      phase,
+      autoMode: null, // Set externally from setStatus events
+    };
+  } catch {
+    // File doesn't exist or can't be read
+    return null;
+  }
+}

--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { GsdRpcClient } from "./rpc-client";
 import { listSessions, deleteSession } from "./session-list-service";
 import { downloadAndInstallUpdate, dismissUpdateVersion } from "./update-checker";
+import { parseGsdWorkflowState } from "./state-parser";
 import type {
   WebviewToExtensionMessage,
   ExtensionToWebviewMessage,
@@ -38,6 +39,8 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
   private statsTimers: Map<string, ReturnType<typeof setInterval>> = new Map();
   private healthTimers: Map<string, ReturnType<typeof setInterval>> = new Map();
   private healthState: Map<string, ProcessHealthStatus> = new Map();
+  private workflowTimers: Map<string, ReturnType<typeof setInterval>> = new Map();
+  private autoModeState: Map<string, string | null> = new Map();
   private sessionWebviews: Map<string, vscode.Webview> = new Map();
   private output: vscode.OutputChannel;
   private sessionCounter = 0;
@@ -266,6 +269,29 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
     // Check every 30 seconds
     const timer = setInterval(check, 30000);
     this.healthTimers.set(sessionId, timer);
+  }
+
+  // --- Workflow state ---
+
+  private async refreshWorkflowState(webview: vscode.Webview, sessionId: string): Promise<void> {
+    const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd();
+    const state = await parseGsdWorkflowState(cwd);
+    if (state) {
+      state.autoMode = this.autoModeState.get(sessionId) || null;
+    }
+    this.postToWebview(webview, { type: "workflow_state", state } as ExtensionToWebviewMessage);
+  }
+
+  private startWorkflowPolling(webview: vscode.Webview, sessionId: string): void {
+    const existing = this.workflowTimers.get(sessionId);
+    if (existing) clearInterval(existing);
+
+    // Initial refresh
+    this.refreshWorkflowState(webview, sessionId);
+
+    // Poll every 30 seconds
+    const timer = setInterval(() => this.refreshWorkflowState(webview, sessionId), 30000);
+    this.workflowTimers.set(sessionId, timer);
   }
 
   // --- Message handling ---
@@ -822,6 +848,12 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
         this.healthTimers.delete(sessionId);
       }
       this.healthState.delete(sessionId);
+      const workflowTimer = this.workflowTimers.get(sessionId);
+      if (workflowTimer) {
+        clearInterval(workflowTimer);
+        this.workflowTimers.delete(sessionId);
+      }
+      this.autoModeState.delete(sessionId);
 
       if (signal !== "SIGTERM" && signal !== "SIGKILL") {
         this.output.appendLine(`[${sessionId}] Unexpected exit — will auto-restart on next prompt`);
@@ -862,9 +894,10 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
         }
       } catch {}
 
-      // Start stats polling and health monitoring
+      // Start stats polling, health monitoring, and workflow state
       this.startStatsPolling(webview, sessionId);
       this.startHealthMonitoring(webview, sessionId);
+      this.startWorkflowPolling(webview, sessionId);
     } catch (err: any) {
       this.postToWebview(webview, {
         type: "process_exit",
@@ -904,6 +937,8 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
       this.emitStatus({ isStreaming: true });
     } else if (eventType === "agent_end") {
       this.emitStatus({ isStreaming: false });
+      // Refresh workflow state after each agent turn
+      this.refreshWorkflowState(webview, sessionId);
     } else if (eventType === "message_end") {
       const msg = event.message;
       const usage = msg?.usage as { cost?: { total?: number } } | undefined;
@@ -974,7 +1009,16 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
         break;
       }
 
-      case "setStatus":
+      case "setStatus": {
+        // Track auto-mode status for workflow badge
+        if (event.statusKey === "gsd-auto") {
+          const autoMode = event.statusText as string | undefined;
+          this.autoModeState.set(sessionId, autoMode || null);
+          this.refreshWorkflowState(webview, sessionId);
+        }
+        this.postToWebview(webview, event as unknown as ExtensionToWebviewMessage);
+        break;
+      }
       case "setWidget":
       case "set_editor_text": {
         this.postToWebview(webview, event as unknown as ExtensionToWebviewMessage);

--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -174,6 +174,10 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
       clearInterval(timer);
     }
     this.healthTimers.clear();
+    for (const [_, timer] of this.workflowTimers) {
+      clearInterval(timer);
+    }
+    this.workflowTimers.clear();
     for (const [_, client] of this.rpcClients) {
       client.stop();
     }
@@ -197,6 +201,12 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
       this.healthTimers.delete(sessionId);
     }
     this.healthState.delete(sessionId);
+    const workflowTimer = this.workflowTimers.get(sessionId);
+    if (workflowTimer) {
+      clearInterval(workflowTimer);
+      this.workflowTimers.delete(sessionId);
+    }
+    this.autoModeState.delete(sessionId);
     const client = this.rpcClients.get(sessionId);
     if (client) {
       client.stop();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -73,7 +73,8 @@ export type ExtensionToWebviewMessage =
   | { type: "session_list"; sessions: SessionListItem[] }
   | { type: "session_switched"; state: GsdState; messages: AgentMessage[] }
   | { type: "session_list_error"; message: string }
-  | { type: "update_available"; version: string; currentVersion: string; releaseNotes: string; downloadUrl: string; htmlUrl: string };
+  | { type: "update_available"; version: string; currentVersion: string; releaseNotes: string; downloadUrl: string; htmlUrl: string }
+  | { type: "workflow_state"; state: WorkflowState | null };
 
 // --- Session List Types ---
 
@@ -233,4 +234,19 @@ export interface RpcStateResult {
   autoCompactionEnabled?: boolean;
   cwd?: string;
   [key: string]: unknown;
+}
+
+// --- Workflow State (parsed from .gsd/STATE.md) ---
+
+export interface WorkflowStateRef {
+  id: string;
+  title: string;
+}
+
+export interface WorkflowState {
+  milestone: WorkflowStateRef | null;
+  slice: WorkflowStateRef | null;
+  task: WorkflowStateRef | null;
+  phase: string;
+  autoMode: string | null;
 }

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -8,6 +8,7 @@ import type {
   ExtensionToWebviewMessage,
   GsdState,
   ProcessStatus,
+  WorkflowState,
 } from "../shared/types";
 import "./styles.css";
 
@@ -102,6 +103,7 @@ root.innerHTML = `
         <span class="gsd-logo">🚀</span>
         <span class="gsd-title">Rokket GSD</span>
       </div>
+      <span class="gsd-workflow-badge" id="workflowBadge" title="GSD workflow state"></span>
       <div class="gsd-header-info">
         <span class="gsd-model-badge" id="modelBadge" title="Model"></span>
         <span class="gsd-thinking-badge" id="thinkingBadge" title="Thinking level"></span>
@@ -110,23 +112,23 @@ root.innerHTML = `
       </div>
       <div class="gsd-header-actions">
         <button class="gsd-action-btn" id="compactBtn" title="Compact context — reduce token usage">
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M14 2H8L7 3v3h1V3h6v5h-4l-1 1v2H8v1h2l3-3h1l1-1V3l-1-1zM9 7H3L2 8v5l1 1h6l1-1V8L9 7zm0 6H3V8h6v5z"/></svg>
+          <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M14 2H8L7 3v3h1V3h6v5h-4l-1 1v2H8v1h2l3-3h1l1-1V3l-1-1zM9 7H3L2 8v5l1 1h6l1-1V8L9 7zm0 6H3V8h6v5z"/></svg>
           <span>Compact</span>
         </button>
         <button class="gsd-action-btn" id="exportBtn" title="Export conversation as HTML">
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M13 1H5L4 2v3h1V2h8v12H5v-3H4v3l1 1h8l1-1V2l-1-1zM1 8l3-3v2h5v2H4v2L1 8z"/></svg>
+          <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M13 1H5L4 2v3h1V2h8v12H5v-3H4v3l1 1h8l1-1V2l-1-1zM1 8l3-3v2h5v2H4v2L1 8z"/></svg>
           <span>Export</span>
         </button>
         <button class="gsd-action-btn" id="historyBtn" title="Browse previous sessions">
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M13.507 12.324a7 7 0 0 0 .065-8.56A7 7 0 0 0 2 4.393V2H1v3.5l.5.5H5V5H2.811a6.008 6.008 0 1 1-.135 5.77l-.887.462a7 7 0 0 0 11.718 1.092zM8 4h1v4.495L11.255 10l-.51.858L7.5 9.166V4H8z"/></svg>
+          <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M13.507 12.324a7 7 0 0 0 .065-8.56A7 7 0 0 0 2 4.393V2H1v3.5l.5.5H5V5H2.811a6.008 6.008 0 1 1-.135 5.77l-.887.462a7 7 0 0 0 11.718 1.092zM8 4h1v4.495L11.255 10l-.51.858L7.5 9.166V4H8z"/></svg>
           <span>History</span>
         </button>
         <button class="gsd-action-btn" id="modelPickerBtn" title="Change AI model">
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1a7 7 0 100 14A7 7 0 008 1zm0 13A6 6 0 118 2a6 6 0 010 12zm0-9.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM4.5 8a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm7 0a1.5 1.5 0 100 3 1.5 1.5 0 000-3z"/></svg>
+          <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1a7 7 0 100 14A7 7 0 008 1zm0 13A6 6 0 118 2a6 6 0 010 12zm0-9.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM4.5 8a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm7 0a1.5 1.5 0 100 3 1.5 1.5 0 000-3z"/></svg>
           <span>Model</span>
         </button>
         <button class="gsd-action-btn primary" id="newConvoBtn" title="Start a new conversation">
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1a.5.5 0 01.5.5V7H14a.5.5 0 010 1H8.5v5.5a.5.5 0 01-1 0V8H2a.5.5 0 010-1h5.5V1.5A.5.5 0 018 1z"/></svg>
+          <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1a.5.5 0 01.5.5V7H14a.5.5 0 010 1H8.5v5.5a.5.5 0 01-1 0V8H2a.5.5 0 010-1h5.5V1.5A.5.5 0 018 1z"/></svg>
           <span>New</span>
         </button>
       </div>
@@ -717,6 +719,80 @@ function updateOverlayIndicators(): void {
   }
 }
 
+function updateWorkflowBadge(wf: WorkflowState | null): void {
+  const badge = document.getElementById("workflowBadge");
+  if (!badge) return;
+
+  if (!wf) {
+    badge.textContent = "Self-directed";
+    badge.className = "gsd-workflow-badge";
+    badge.style.display = "inline-flex";
+    return;
+  }
+
+  const parts: string[] = [];
+
+  // Build breadcrumb: M004 › S02 › T03
+  if (wf.milestone) parts.push(wf.milestone.id);
+  if (wf.slice) parts.push(wf.slice.id);
+  if (wf.task) parts.push(wf.task.id);
+
+  // Phase label
+  const phaseLabels: Record<string, string> = {
+    "pre-planning": "Pre-planning",
+    "discussing": "Discussing",
+    "researching": "Researching",
+    "planning": "Planning",
+    "executing": "Executing",
+    "verifying": "Verifying",
+    "summarizing": "Summarizing",
+    "advancing": "Advancing",
+    "completing-milestone": "Completing",
+    "replanning-slice": "Replanning",
+    "complete": "Complete",
+    "paused": "Paused",
+    "blocked": "Blocked",
+    "unknown": "",
+  };
+  const phaseText = phaseLabels[wf.phase] || wf.phase;
+
+  // Build display text
+  let text = "";
+  if (parts.length > 0) {
+    text = parts.join(" › ");
+    if (phaseText && phaseText !== "Complete") {
+      text += ` · ${phaseText}`;
+    } else if (phaseText === "Complete") {
+      text += " ✓";
+    }
+  } else if (phaseText) {
+    text = phaseText;
+  } else {
+    text = "Self-directed";
+  }
+
+  // Auto-mode prefix
+  if (wf.autoMode === "auto") {
+    text = `⚡ ${text}`;
+  } else if (wf.autoMode === "next") {
+    text = `▸ ${text}`;
+  } else if (wf.autoMode === "paused") {
+    text = `⏸ ${text}`;
+  }
+
+  badge.textContent = text;
+
+  // Phase-based styling
+  let extraClass = "";
+  if (wf.phase === "blocked") extraClass = " blocked";
+  else if (wf.phase === "paused") extraClass = " paused";
+  else if (wf.phase === "complete") extraClass = " complete";
+  else if (wf.autoMode) extraClass = " auto";
+
+  badge.className = `gsd-workflow-badge${extraClass}`;
+  badge.style.display = "inline-flex";
+}
+
 function updateWelcomeScreen(): void {
   if (state.entries.length > 0 || state.currentTurn) {
     welcomeScreen.style.display = "none";
@@ -831,6 +907,11 @@ window.addEventListener("message", (event) => {
       state.processStatus = data.status as ProcessStatus;
       updateOverlayIndicators();
       updateWelcomeScreen();
+      break;
+    }
+
+    case "workflow_state": {
+      updateWorkflowBadge(msg.state);
       break;
     }
 

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -44,37 +44,77 @@ html, body {
 .gsd-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
+  gap: 10px;
+  padding: 8px 16px;
   border-bottom: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
   flex-shrink: 0;
   background: var(--vscode-sideBar-background, var(--vscode-editor-background));
-  min-height: 36px;
+  min-height: 46px;
+  flex-wrap: wrap;
 }
 
 .gsd-header-brand {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   flex-shrink: 0;
 }
 
 .gsd-logo {
-  font-size: 14px;
+  font-size: 18px;
   line-height: 1;
 }
 
 .gsd-title {
   font-weight: 700;
-  font-size: 13px;
+  font-size: 15px;
   letter-spacing: 1px;
   text-transform: uppercase;
+}
+
+.gsd-workflow-badge {
+  display: none;
+  align-items: center;
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-weight: 500;
+  font-family: var(--vscode-editor-fontFamily, 'Cascadia Code', Consolas, monospace);
+  letter-spacing: 0.2px;
+  background: rgba(80, 160, 220, 0.1);
+  color: rgba(120, 180, 240, 0.85);
+  min-height: 26px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 280px;
+  flex-shrink: 1;
+}
+
+.gsd-workflow-badge.auto {
+  background: rgba(80, 200, 120, 0.12);
+  color: rgba(100, 210, 140, 0.9);
+}
+
+.gsd-workflow-badge.blocked {
+  background: rgba(220, 60, 60, 0.12);
+  color: var(--vscode-errorForeground, #f48771);
+}
+
+.gsd-workflow-badge.paused {
+  background: rgba(220, 160, 40, 0.12);
+  color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.gsd-workflow-badge.complete {
+  background: rgba(80, 180, 80, 0.1);
+  color: rgba(120, 200, 120, 0.85);
 }
 
 .gsd-header-info {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -86,15 +126,15 @@ html, body {
 .gsd-context-badge {
   display: none;
   align-items: center;
-  font-size: 10px;
-  padding: 2px 8px;
+  font-size: 12px;
+  padding: 3px 10px;
   border-radius: 4px;
   white-space: nowrap;
   line-height: 1.8;
   font-weight: 500;
   font-family: var(--vscode-editor-fontFamily, 'Cascadia Code', Consolas, monospace);
   letter-spacing: 0.2px;
-  min-height: 22px;
+  min-height: 28px;
 }
 
 .gsd-model-badge {
@@ -143,7 +183,7 @@ html, body {
 .gsd-header-actions {
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: 4px;
   flex-shrink: 0;
 }
 
@@ -151,8 +191,8 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 34px;
+  height: 34px;
   border: none;
   border-radius: 4px;
   background: transparent;
@@ -168,22 +208,22 @@ html, body {
 }
 
 .gsd-icon-btn svg {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
 }
 
 /* Labeled action buttons */
 .gsd-action-btn {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
+  gap: 5px;
+  padding: 5px 10px;
   border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
   border-radius: 4px;
   background: transparent;
   color: var(--vscode-foreground);
   cursor: pointer;
-  font-size: 10px;
+  font-size: 12px;
   font-family: var(--vscode-font-family);
   font-weight: 500;
   opacity: 0.6;
@@ -193,8 +233,8 @@ html, body {
 }
 
 .gsd-action-btn svg {
-  width: 12px;
-  height: 12px;
+  width: 16px;
+  height: 16px;
   flex-shrink: 0;
 }
 
@@ -222,9 +262,14 @@ html, body {
 }
 
 /* Hide labels at narrow widths */
-@media (max-width: 350px) {
+@media (max-width: 420px) {
   .gsd-action-btn span { display: none; }
-  .gsd-action-btn { padding: 4px 5px; }
+  .gsd-action-btn { padding: 5px 6px; }
+  .gsd-workflow-badge { max-width: 140px; }
+}
+
+@media (max-width: 350px) {
+  .gsd-workflow-badge { display: none !important; }
 }
 
 /* ============================================================
@@ -2105,8 +2150,8 @@ html, body {
    ============================================================ */
 
 @media (max-width: 400px) {
-  .gsd-header { padding: 5px 8px; gap: 4px; }
-  .gsd-header-info { gap: 3px; }
+  .gsd-header { padding: 6px 10px; gap: 6px; }
+  .gsd-header-info { gap: 4px; }
   .gsd-messages { padding: 8px; }
   .gsd-input-area { padding: 6px 8px 4px; }
   .gsd-user-bubble { max-width: 95%; }


### PR DESCRIPTION
## What

Two header enhancements:

1. **GSD workflow state badge** — shows the active milestone/slice/task and current phase, parsed from `.gsd/STATE.md`
2. **~30% header size bump** — all badges, buttons, and brand elements are larger for better readability

## Workflow Badge

| State | Display |
|-------|---------|
| No `.gsd/` | `Self-directed` |
| Active milestone | `M004 · Executing` |
| Full breadcrumb | `M004 › S02 › T03 · Executing` |
| Auto-mode | `⚡ M004 › S01 · Executing` |
| Blocked | `M004 › S02 · Blocked` (red) |
| Paused | `⏸ M004 · Paused` (yellow) |
| Complete | `M003 ✓` (green) |

**Data source:** Parses `.gsd/STATE.md` on disk (Decision #11). The RPC `get_state` does not expose GSD workflow state, and `setWidget` progress data uses factory functions which RPC mode silently drops.

**Refresh triggers:** Launch, `agent_end` events, `setStatus("gsd-auto", ...)` changes, and 30s poll.

## Header Sizing

| Element | Before | After |
|---------|--------|-------|
| Badges (model, thinking, cost, context) | 10px font, 22px height | 12px font, 28px height |
| Action buttons | 10px font, 12px SVG | 12px font, 16px SVG |
| Brand logo | 14px | 18px |
| Brand title | 13px | 15px |
| Header min-height | 36px | 46px |
| Inline SVGs | 14×14 | 18×18 |

## Files Changed

- `src/extension/state-parser.ts` — new: STATE.md parser
- `src/shared/types.ts` — `WorkflowState` type + `workflow_state` message
- `src/extension/webview-provider.ts` — wiring: refresh triggers, auto-mode tracking, polling
- `src/webview/index.ts` — workflow badge element + update handler, larger SVGs
- `src/webview/styles.css` — workflow badge styles + all size bumps

## Testing

- STATE.md parser tested against all 13 phases + missing file + partial data
- Build passes clean
- Responsive: badge truncates at ≤420px, hides at ≤350px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow state badge in header showing active milestone, slice and task with auto-mode indicator (⚡ Auto, ▸ Next, ⏸ Paused)
  * Workflow state refreshes on agent turns and every 30s

* **Changed**
  * Header components ~30% larger: badges, buttons, branding; increased header min-height and updated responsive breakpoints
  * Action icons and labeled buttons enlarged for improved readability
  * Phase-specific badge colours: blue (active), green (auto/complete), yellow (paused), red (blocked)

* **Removed**
  * Session history panel and history button in header
<!-- end of auto-generated comment: release notes by coderabbit.ai -->