### PR TITLE
fix: slash commands work during streaming + watchdog false alarms

### DIFF
--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -301,6 +301,42 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
     }
   }
 
+  /**
+   * Abort the current stream and re-send a slash command as a prompt.
+   * Uses bounded retry to wait for the abort to settle before prompting.
+   */
+  private async abortAndPrompt(
+    client: RpcClient,
+    webview: vscode.Webview,
+    message: string,
+    images?: Array<{ data: string; mimeType: string }>,
+  ): Promise<void> {
+    try { await client.abort(); } catch { /* may not be streaming */ }
+
+    const imgs = images?.map((img) => ({
+      type: "image" as const,
+      data: img.data,
+      mimeType: img.mimeType,
+    }));
+
+    // Bounded retry — wait for stream teardown before sending the command
+    const MAX_ATTEMPTS = 5;
+    const RETRY_DELAY_MS = 150;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        await client.prompt(message, imgs);
+        return;
+      } catch (err: any) {
+        if (err.message?.includes("streaming") && attempt < MAX_ATTEMPTS - 1) {
+          await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+          continue;
+        }
+        this.postToWebview(webview, { type: "error", message: err.message });
+        return;
+      }
+    }
+  }
+
   // --- What's New on first launch after update ---
 
   private static readonly LAST_VERSION_KEY = "gsd.lastSeenVersion";
@@ -524,12 +560,18 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
               }
             } catch (err: any) {
               if (err.message?.includes("streaming")) {
+                const isSlash = msg.message.trimStart().startsWith("/");
                 try {
-                  await c.steer(msg.message, msg.images?.map((img) => ({
+                  const imgs = msg.images?.map((img) => ({
                     type: "image" as const,
                     data: img.data,
                     mimeType: img.mimeType,
-                  })));
+                  }));
+                  if (isSlash) {
+                    await this.abortAndPrompt(c, webview, msg.message, msg.images);
+                  } else {
+                    await c.steer(msg.message, imgs);
+                  }
                 } catch (steerErr: any) {
                   this.postToWebview(webview, { type: "error", message: steerErr.message });
                 }
@@ -558,20 +600,7 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
               // Extension commands (slash commands) can't be steered — they need to run
               // as prompts. Abort the current stream first, then send as a prompt.
               if (msg.message.startsWith("/")) {
-                try {
-                  await client.abort();
-                } catch { /* may not be streaming anymore */ }
-                // Small delay to let the abort settle before sending the command
-                await new Promise((r) => setTimeout(r, 200));
-                try {
-                  await client.prompt(msg.message, msg.images?.map((img) => ({
-                    type: "image" as const,
-                    data: img.data,
-                    mimeType: img.mimeType,
-                  })));
-                } catch (promptErr: any) {
-                  this.postToWebview(webview, { type: "error", message: promptErr.message });
-                }
+                await this.abortAndPrompt(client, webview, msg.message, msg.images);
               } else {
                 await client.steer(msg.message, msg.images?.map((img) => ({
                   type: "image" as const,

--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -517,7 +517,11 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
                 mimeType: img.mimeType,
               }));
               await c.prompt(msg.message, images);
-              this.startPromptWatchdog(webview, sessionId, msg.message, images);
+              // Don't start watchdog for slash commands — they're handled by pi extensions
+              // internally and don't emit agent_start events, causing false watchdog alarms
+              if (!msg.message.startsWith("/")) {
+                this.startPromptWatchdog(webview, sessionId, msg.message, images);
+              }
             } catch (err: any) {
               if (err.message?.includes("streaming")) {
                 try {
@@ -551,11 +555,30 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
           const client = this.rpcClients.get(sessionId);
           if (client) {
             try {
-              await client.steer(msg.message, msg.images?.map((img) => ({
-                type: "image" as const,
-                data: img.data,
-                mimeType: img.mimeType,
-              })));
+              // Extension commands (slash commands) can't be steered — they need to run
+              // as prompts. Abort the current stream first, then send as a prompt.
+              if (msg.message.startsWith("/")) {
+                try {
+                  await client.abort();
+                } catch { /* may not be streaming anymore */ }
+                // Small delay to let the abort settle before sending the command
+                await new Promise((r) => setTimeout(r, 200));
+                try {
+                  await client.prompt(msg.message, msg.images?.map((img) => ({
+                    type: "image" as const,
+                    data: img.data,
+                    mimeType: img.mimeType,
+                  })));
+                } catch (promptErr: any) {
+                  this.postToWebview(webview, { type: "error", message: promptErr.message });
+                }
+              } else {
+                await client.steer(msg.message, msg.images?.map((img) => ({
+                  type: "image" as const,
+                  data: img.data,
+                  mimeType: img.mimeType,
+                })));
+              }
             } catch (err: any) {
               this.postToWebview(webview, { type: "error", message: err.message });
             }

--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -306,7 +306,7 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
    * Uses bounded retry to wait for the abort to settle before prompting.
    */
   private async abortAndPrompt(
-    client: RpcClient,
+    client: GsdRpcClient,
     webview: vscode.Webview,
     message: string,
     images?: Array<{ data: string; mimeType: string }>,
@@ -328,6 +328,7 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
         return;
       } catch (err: any) {
         if (err.message?.includes("streaming") && attempt < MAX_ATTEMPTS - 1) {
+          this.output.appendLine(`[abortAndPrompt] Retry ${attempt + 1}/${MAX_ATTEMPTS - 1}: stream not yet settled`);
           await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
           continue;
         }

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -419,7 +419,7 @@ function sendMessage(): void {
     : "";
 
   // Handle /gsd status — show dashboard inline (no streaming guard — this is local UI only)
-  if (text === "/gsd status") {
+  if (text.toLowerCase() === "/gsd status") {
     state.entries.push({
       id: nextId(),
       type: "user",

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -59,7 +59,13 @@ export function clearMessages(): void {
 
 export function renderNewEntry(entry: ChatEntry): void {
   const el = createEntryElement(entry);
-  messagesContainer.appendChild(el);
+  // If streaming, insert before the current streaming element so user messages
+  // don't appear below the in-progress assistant response
+  if (currentTurnElement && currentTurnElement.parentNode === messagesContainer) {
+    messagesContainer.insertBefore(el, currentTurnElement);
+  } else {
+    messagesContainer.appendChild(el);
+  }
 }
 
 // ============================================================


### PR DESCRIPTION
## Problem

Slash commands (`/gsd auto`, `/gsd stop`, etc.) failed silently when sent while the agent was mid-response:

1. **Steer rejection**: Pi's steer handler explicitly rejects extension commands, so `/gsd stop` sent during streaming was silently dropped
2. **Watchdog false alarms**: The prompt watchdog expected an `agent_start` event after slash commands, but extension commands don't emit one — causing false "GSD accepted the command but didn't start processing" errors after 8s
3. **User messages rendered below streaming response** instead of above it

## Fix

- **Steer path for slash commands**: When a message starting with `/` is sent during streaming, abort the current stream first, then re-send as a prompt so the extension command executes
- **Watchdog skip**: Don't start the prompt watchdog for messages starting with `/`
- **Case-insensitive** `/gsd status` check
- **Renderer ordering**: Insert user messages above the in-progress streaming element

## Testing

1. Start `/gsd auto` → guided flow asks a question
2. While agent is responding, send `/gsd stop` → should interrupt and stop
3. Send `/gsd auto` again → should start fresh (no "Discussion already in progress")
4. Send any slash command while streaming → should execute cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Slash commands now retry more robustly on streaming errors with bounded retries while preserving images for more reliable prompts.
  * Prompt watchdog now only starts for non-slash prompts to reduce unnecessary restarts.
  * /gsd status is case-insensitive for improved usability.
  * Message ordering during streaming fixed so new user messages appear above active assistant responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->