### PR TITLE
fix: replace event-based timeouts with ping-based monitoring

### DIFF
--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -419,17 +419,26 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
   }
 
   /**
-   * Streaming activity monitor — checks that RPC events keep flowing during
-   * an active agent turn. If no events arrive for STALL_TIMEOUT_MS, sends an
-   * abort to recover. This mirrors the CLI's built-in recovery: the CLI
-   * controls the agent loop directly and never hangs indefinitely, but the
-   * extension is a passive observer that needs its own stall detection.
+   * Streaming activity monitor — uses health pings to detect truly stuck
+   * processes during an active agent turn.
+   *
+   * Why ping-based, not event-based: Long-running tools (subagent, bg_shell)
+   * may not emit ANY intermediate events through RPC for 5+ minutes while
+   * doing real work. Event-based monitoring would abort healthy work.
+   * Ping-based monitoring only fires when the GSD process itself is
+   * unresponsive — meaning it can't even answer a get_state request.
+   *
+   * Escalation:
+   *  1. First unresponsive ping → log, notify webview, keep monitoring
+   *  2. Two consecutive unresponsive pings → abort
+   *  3. Abort fails → force-kill
    */
   private startActivityMonitor(webview: vscode.Webview, sessionId: string, client: GsdRpcClient): void {
     this.stopActivityMonitor(sessionId);
 
-    const STALL_TIMEOUT_MS = 120_000; // 2 minutes with no events = stalled
-    const CHECK_INTERVAL_MS = 15_000; // check every 15s
+    const CHECK_INTERVAL_MS = 30_000; // check every 30s
+    const PING_TIMEOUT_MS = 15_000;   // individual ping timeout
+    let consecutiveFailures = 0;
 
     const timer = setInterval(async () => {
       // Only act while streaming
@@ -438,39 +447,62 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
         return;
       }
 
-      const lastEvent = this.lastEventTime.get(sessionId) || 0;
-      const elapsed = Date.now() - lastEvent;
-
-      if (elapsed >= STALL_TIMEOUT_MS) {
-        this.output.appendLine(`[${sessionId}] Activity monitor: no events for ${Math.round(elapsed / 1000)}s — aborting to recover`);
+      if (!client.isRunning) {
         this.stopActivityMonitor(sessionId);
+        return;
+      }
 
-        // Notify the webview
+      const isAlive = await client.ping(PING_TIMEOUT_MS);
+
+      if (isAlive) {
+        // Process is responsive — reset failure count
+        if (consecutiveFailures > 0) {
+          this.output.appendLine(`[${sessionId}] Activity monitor: process recovered after ${consecutiveFailures} failed ping(s)`);
+          consecutiveFailures = 0;
+        }
+        return;
+      }
+
+      consecutiveFailures++;
+      this.output.appendLine(`[${sessionId}] Activity monitor: ping failed (${consecutiveFailures} consecutive)`);
+
+      if (consecutiveFailures === 1) {
+        // First failure — warn but don't act yet (could be transient)
         this.postToWebview(webview, {
           type: "error",
-          message: `No activity for ${Math.round(elapsed / 1000)}s — sending abort to recover.`,
+          message: "GSD process is not responding — monitoring...",
         } as ExtensionToWebviewMessage);
+        return;
+      }
 
-        // Try graceful abort first
-        try {
-          await client.abort();
-          // Wait a moment for agent_end to arrive naturally
-          await new Promise(r => setTimeout(r, 3000));
-          // If still streaming, force-push agent_end to unblock the webview
-          if (this.isSessionStreaming.get(sessionId)) {
-            this.output.appendLine(`[${sessionId}] Activity monitor: abort succeeded but no agent_end — forcing`);
-            this.isSessionStreaming.set(sessionId, false);
-            this.emitStatus({ isStreaming: false });
-            this.postToWebview(webview, { type: "agent_end", messages: [] } as ExtensionToWebviewMessage);
-          }
-        } catch {
-          // If abort fails, the process may be truly hung — force kill
-          this.output.appendLine(`[${sessionId}] Activity monitor: abort failed, force-killing`);
+      // Two or more consecutive failures — process is truly stuck
+      this.output.appendLine(`[${sessionId}] Activity monitor: ${consecutiveFailures} consecutive ping failures — aborting`);
+      this.stopActivityMonitor(sessionId);
+
+      this.postToWebview(webview, {
+        type: "error",
+        message: `GSD process unresponsive for ${consecutiveFailures * CHECK_INTERVAL_MS / 1000}s — aborting to recover.`,
+      } as ExtensionToWebviewMessage);
+
+      // Try graceful abort first
+      try {
+        await client.abort();
+        // Wait a moment for agent_end to arrive naturally
+        await new Promise(r => setTimeout(r, 3000));
+        // If still streaming, force-push agent_end to unblock the webview
+        if (this.isSessionStreaming.get(sessionId)) {
+          this.output.appendLine(`[${sessionId}] Activity monitor: abort succeeded but no agent_end — forcing`);
           this.isSessionStreaming.set(sessionId, false);
           this.emitStatus({ isStreaming: false });
           this.postToWebview(webview, { type: "agent_end", messages: [] } as ExtensionToWebviewMessage);
-          client.forceKill();
         }
+      } catch {
+        // If abort fails, the process may be truly hung — force kill
+        this.output.appendLine(`[${sessionId}] Activity monitor: abort failed, force-killing`);
+        this.isSessionStreaming.set(sessionId, false);
+        this.emitStatus({ isStreaming: false });
+        this.postToWebview(webview, { type: "agent_end", messages: [] } as ExtensionToWebviewMessage);
+        client.forceKill();
       }
     }, CHECK_INTERVAL_MS);
 

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -44,20 +44,26 @@ const vscode = acquireVsCodeApi();
 // Tool Watchdog — Client-side timeout for stuck tools
 // ============================================================
 
-/** Default watchdog timeout: 3 minutes (180s). GSD's bash-safety is 120s,
- *  so this catches anything that slips through or isn't covered by bash-safety. */
-const TOOL_WATCHDOG_TIMEOUT_MS = 180_000;
+/**
+ * Tool watchdog — NO hard timeout. Long-running tools (subagent, bg_shell)
+ * routinely run 5+ minutes without emitting intermediate events through RPC.
+ * A hard timeout would abort healthy work.
+ *
+ * True hangs are detected by the extension host's ping-based activity monitor,
+ * which checks if the GSD process can respond to health pings regardless of
+ * event flow. The user can always press Escape to interrupt manually.
+ *
+ * The watchdog maps are kept for the message handler's clearToolWatchdog calls
+ * but startToolWatchdog is now a no-op.
+ */
 
-/** Map of toolCallId → timer handle for active watchdog timers */
+/** Map of toolCallId → timer handle (kept for API compat, not actively used) */
 const toolWatchdogTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-function startToolWatchdog(toolCallId: string): void {
-  clearToolWatchdog(toolCallId);
-  const timer = setTimeout(() => {
-    toolWatchdogTimers.delete(toolCallId);
-    handleToolWatchdogTimeout(toolCallId);
-  }, TOOL_WATCHDOG_TIMEOUT_MS);
-  toolWatchdogTimers.set(toolCallId, timer);
+function startToolWatchdog(_toolCallId: string): void {
+  // No-op — hang detection is handled by the extension host's ping-based
+  // activity monitor. Client-side hard timeouts cause false alarms on
+  // long-running tools like subagent.
 }
 
 function clearToolWatchdog(toolCallId: string): void {
@@ -66,49 +72,6 @@ function clearToolWatchdog(toolCallId: string): void {
     clearTimeout(timer);
     toolWatchdogTimers.delete(toolCallId);
   }
-}
-
-function handleToolWatchdogTimeout(toolCallId: string): void {
-  // Mark the tool as timed out in state
-  const tc = state.currentTurn?.toolCalls.get(toolCallId);
-  if (!tc || !tc.isRunning) return;
-
-  tc.isRunning = false;
-  tc.isError = true;
-  tc.endTime = Date.now();
-  tc.resultText = `⏱ Tool timed out after ${TOOL_WATCHDOG_TIMEOUT_MS / 1000}s (client-side watchdog). The tool may still be running on the server.`;
-
-  // Re-render the tool card with timeout state
-  renderer.updateToolSegmentElement(toolCallId);
-
-  // Show a system message
-  messageHandler.addSystemEntry(
-    `Tool "${tc.name}" timed out after ${TOOL_WATCHDOG_TIMEOUT_MS / 1000}s. Sending interrupt to recover...`,
-    "warning"
-  );
-
-  // Auto-interrupt to recover — the server-side tool may have finished but
-  // the result event was lost, or the agent is stuck. Interrupting will
-  // trigger agent_end and clear streaming state so the user can continue.
-  vscode.postMessage({ type: "interrupt" });
-
-  // Safety net: if interrupt doesn't clear streaming within 15s, force-clear
-  // client-side state so the user isn't permanently stuck.
-  setTimeout(() => {
-    if (state.isStreaming && state.currentTurn && !state.currentTurn.isComplete) {
-      state.isStreaming = false;
-      if (state.currentTurn) {
-        state.currentTurn.isComplete = true;
-        renderer.finalizeCurrentTurn();
-      }
-      messageHandler.addSystemEntry(
-        "Interrupt did not resolve — streaming state force-cleared. You can send a new message.",
-        "warning"
-      );
-      uiUpdates.updateInputUI();
-      uiUpdates.updateFooterUI();
-    }
-  }, 15_000);
 }
 
 // ============================================================


### PR DESCRIPTION
Long-running tools (subagent, bg_shell) run 5+ minutes without emitting intermediate RPC events. The previous event-based timeouts (120s activity monitor, 180s tool watchdog) would abort healthy work.

Now uses ping-based liveness: if the GSD process responds to health pings, it's alive regardless of event flow. Escalation: warn on first failed ping, abort on second consecutive, force-kill if abort fails. Client-side hard timeout removed entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced system reliability with improved health check monitoring and automatic recovery for unresponsive connections.

* **Refactor**
  * Replaced stall-based monitoring with periodic health checks for more responsive system behaviour.
  * Simplified client-side timeout management to reduce overhead and improve system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->