### PR TITLE
fix: live elapsed timer on running tools + ping-based monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ nul
 .gsd/metrics.json
 .gsd/completed-units.json
 .gsd/STATE.md
+scripts/*-results.json

--- a/scripts/rpc-streaming-diagnostic.mjs
+++ b/scripts/rpc-streaming-diagnostic.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+/**
+ * RPC Streaming Diagnostic — measures event flow timing from GSD's RPC mode.
+ *
+ * Spawns GSD in RPC mode, sends prompts that trigger tool execution,
+ * and logs every event with precise timestamps to identify streaming gaps.
+ *
+ * Usage: node scripts/rpc-streaming-diagnostic.mjs
+ */
+
+import { spawn, spawnSync } from "child_process";
+import { createInterface } from "readline";
+import path from "path";
+import fs from "fs";
+
+// ── Resolve GSD binary (same logic as rpc-client.ts) ──────────────────
+
+function resolveGsd() {
+  if (process.platform === "win32") {
+    const result = spawnSync("where", ["gsd.cmd"], { encoding: "utf-8", timeout: 5000 });
+    if (result.status === 0 && result.stdout) {
+      const cmdPath = result.stdout.trim().split(/\r?\n/)[0];
+      if (cmdPath && fs.existsSync(cmdPath)) {
+        // Parse .cmd to find JS entry
+        const content = fs.readFileSync(cmdPath, "utf-8");
+        const match = content.match(/"%_prog%"\s+"([^"]+)"\s+%\*/);
+        if (match) {
+          let entryPath = match[1].replace(/%dp0%\\/gi, "").replace(/%dp0%/gi, "");
+          const fullPath = path.resolve(path.dirname(cmdPath), entryPath);
+          if (fs.existsSync(fullPath)) {
+            const nodeResult = spawnSync("where", ["node"], { encoding: "utf-8", timeout: 5000 });
+            const nodePath = nodeResult.stdout?.trim().split(/\r?\n/)[0] || "node";
+            return { command: nodePath, args: [fullPath] };
+          }
+        }
+      }
+    }
+  }
+  return { command: "gsd", args: [] };
+}
+
+// ── State ──────────────────────────────────────────────────────────────
+
+const events = [];
+let startTime = null;
+let requestId = 0;
+let lastEventTime = null;
+
+function elapsed() {
+  return startTime ? Date.now() - startTime : 0;
+}
+
+function gap() {
+  if (!lastEventTime) return 0;
+  return Date.now() - lastEventTime;
+}
+
+// ── Spawn GSD in RPC mode ─────────────────────────────────────────────
+
+const resolved = resolveGsd();
+console.log(`\n🔧 Spawning: ${resolved.command} ${resolved.args.join(" ")} --mode rpc`);
+console.log(`   CWD: ${process.cwd()}\n`);
+
+// Strip VS Code / Electron env vars
+const cleanEnv = {};
+for (const [key, value] of Object.entries(process.env)) {
+  if (key.startsWith("VSCODE_") || key.startsWith("ELECTRON_") || key === "NODE_OPTIONS") continue;
+  cleanEnv[key] = value;
+}
+cleanEnv.NO_COLOR = "1";
+cleanEnv.FORCE_COLOR = "0";
+
+const proc = spawn(resolved.command, [...resolved.args, "--mode", "rpc"], {
+  cwd: process.cwd(),
+  env: cleanEnv,
+  stdio: ["pipe", "pipe", "pipe"],
+  windowsHide: true,
+});
+
+console.log(`   PID: ${proc.pid}\n`);
+
+// ── Parse stdout as JSONL ─────────────────────────────────────────────
+
+let buffer = "";
+proc.stdout.on("data", (chunk) => {
+  const now = Date.now();
+  const chunkStr = chunk.toString("utf-8");
+  const rawLines = chunkStr.split("\n").filter(l => l.trim());
+
+  buffer += chunkStr;
+  while (true) {
+    const idx = buffer.indexOf("\n");
+    if (idx === -1) break;
+    let line = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 1);
+    if (line.endsWith("\r")) line = line.slice(0, -1);
+    if (!line.trim()) continue;
+
+    try {
+      const msg = JSON.parse(line);
+      const eventType = msg.type || "unknown";
+
+      if (!startTime) startTime = now;
+
+      const record = {
+        t: now,
+        elapsed: elapsed(),
+        gap: gap(),
+        type: eventType,
+        toolName: msg.toolName || undefined,
+        toolCallId: msg.toolCallId ? "…" + msg.toolCallId.slice(-6) : undefined,
+        hasPartialResult: eventType === "tool_execution_update" ? !!msg.partialResult : undefined,
+        partialLen: msg.partialResult?.content?.[0]?.text?.length || undefined,
+      };
+      events.push(record);
+      lastEventTime = now;
+
+      // Pretty-print
+      const parts = [`+${String(record.elapsed).padStart(7)}ms`];
+      if (record.gap > 100) parts.push(`gap=${record.gap}ms`);
+      parts.push(eventType);
+      if (record.toolName) parts.push(`tool=${record.toolName}`);
+      if (record.toolCallId) parts.push(`id=${record.toolCallId}`);
+      if (record.partialLen) parts.push(`partial=${record.partialLen}ch`);
+
+      // Highlight gaps > 1s
+      const prefix = record.gap > 1000 ? "⚠️ " : record.gap > 5000 ? "🔴" : "  ";
+      console.log(`${prefix}${parts.join("  ")}`);
+
+      // Response to our request
+      if (msg.type === "response") {
+        console.log(`   ↳ response: command=${msg.command} success=${msg.success}`);
+      }
+    } catch {
+      // Not JSON — skip
+    }
+  }
+});
+
+proc.stderr.on("data", (chunk) => {
+  const text = chunk.toString("utf-8").trim();
+  if (text) {
+    for (const line of text.split("\n")) {
+      console.log(`   [stderr] ${line}`);
+    }
+  }
+});
+
+proc.on("exit", (code, signal) => {
+  console.log(`\n📊 Process exited: code=${code} signal=${signal}`);
+  printSummary();
+  process.exit(0);
+});
+
+// ── RPC helpers ───────────────────────────────────────────────────────
+
+function send(obj) {
+  const id = `diag-${++requestId}`;
+  const withId = { ...obj, id };
+  proc.stdin.write(JSON.stringify(withId) + "\n");
+  return id;
+}
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+// ── Summary ───────────────────────────────────────────────────────────
+
+function printSummary() {
+  console.log("\n" + "=".repeat(70));
+  console.log("STREAMING DIAGNOSTIC SUMMARY");
+  console.log("=".repeat(70));
+
+  const totalEvents = events.length;
+  const toolUpdates = events.filter(e => e.type === "tool_execution_update");
+  const toolStarts = events.filter(e => e.type === "tool_execution_start");
+  const toolEnds = events.filter(e => e.type === "tool_execution_end");
+  const gaps1s = events.filter(e => e.gap > 1000);
+  const gaps5s = events.filter(e => e.gap > 5000);
+  const gaps30s = events.filter(e => e.gap > 30000);
+  const maxGap = Math.max(0, ...events.map(e => e.gap));
+
+  console.log(`Total events:          ${totalEvents}`);
+  console.log(`Tool starts:           ${toolStarts.length}`);
+  console.log(`Tool updates:          ${toolUpdates.length}`);
+  console.log(`Tool ends:             ${toolEnds.length}`);
+  console.log(`Gaps > 1s:             ${gaps1s.length}`);
+  console.log(`Gaps > 5s:             ${gaps5s.length}`);
+  console.log(`Gaps > 30s:            ${gaps30s.length}`);
+  console.log(`Max gap:               ${maxGap}ms (${(maxGap / 1000).toFixed(1)}s)`);
+
+  if (toolStarts.length > 0) {
+    console.log("\nPer-tool breakdown:");
+    for (const start of toolStarts) {
+      const end = toolEnds.find(e => e.toolCallId === start.toolCallId);
+      const updates = toolUpdates.filter(e => e.toolCallId === start.toolCallId);
+      const duration = end ? end.t - start.t : "still running";
+      console.log(`  ${start.toolName} (${start.toolCallId}):`);
+      console.log(`    Duration: ${typeof duration === "number" ? `${duration}ms` : duration}`);
+      console.log(`    Updates:  ${updates.length}`);
+      if (updates.length > 0) {
+        const updateGaps = updates.map(u => u.gap);
+        console.log(`    Update gaps: min=${Math.min(...updateGaps)}ms max=${Math.max(...updateGaps)}ms avg=${Math.round(updateGaps.reduce((a, b) => a + b, 0) / updateGaps.length)}ms`);
+      }
+    }
+  }
+
+  if (gaps5s.length > 0) {
+    console.log("\n⚠️  Significant gaps (>5s):");
+    for (const g of gaps5s) {
+      console.log(`  ${g.gap}ms before ${g.type} ${g.toolName || ""}`);
+    }
+  }
+
+  console.log("=".repeat(70));
+
+  // Write raw data to file
+  const outPath = path.join(process.cwd(), "scripts", "rpc-diagnostic-results.json");
+  fs.writeFileSync(outPath, JSON.stringify(events, null, 2));
+  console.log(`\nRaw data: ${outPath}`);
+}
+
+// ── Test sequence ─────────────────────────────────────────────────────
+
+async function run() {
+  // Wait for process to be ready
+  await sleep(3000);
+
+  console.log("─".repeat(70));
+  console.log("TEST 1: Simple bash tool (should stream stdout chunks)");
+  console.log("─".repeat(70));
+
+  // Send a prompt that triggers a bash tool with incremental output
+  send({
+    type: "prompt",
+    message: 'Run this exact bash command and show me the output: for i in 1 2 3 4 5; do echo "Line $i at $(date +%H:%M:%S)"; sleep 2; done'
+  });
+
+  // Wait for the bash to complete (5 iterations × 2s = ~10s + overhead)
+  await sleep(30000);
+
+  console.log("\n" + "─".repeat(70));
+  console.log("TEST 2: Multi-tool sequence (read + bash)");
+  console.log("─".repeat(70));
+
+  send({
+    type: "prompt",
+    message: "Read the file package.json and then run: echo 'done reading'"
+  });
+
+  await sleep(20000);
+
+  // Shut down
+  console.log("\n" + "─".repeat(70));
+  console.log("Shutting down...");
+  console.log("─".repeat(70));
+
+  proc.stdin.write(JSON.stringify({ type: "abort", id: "abort-1" }) + "\n");
+  await sleep(2000);
+  proc.kill("SIGTERM");
+  await sleep(3000);
+  
+  // Force exit if still alive
+  try { proc.kill("SIGKILL"); } catch {}
+  printSummary();
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error("Diagnostic failed:", err);
+  proc.kill();
+  process.exit(1);
+});

--- a/scripts/rpc-subagent-diagnostic.mjs
+++ b/scripts/rpc-subagent-diagnostic.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * RPC Subagent Streaming Diagnostic — specifically tests whether subagent
+ * tool_execution_update events flow during long agent runs.
+ */
+
+import { spawn, spawnSync } from "child_process";
+import path from "path";
+import fs from "fs";
+
+function resolveGsd() {
+  if (process.platform === "win32") {
+    const result = spawnSync("where", ["gsd.cmd"], { encoding: "utf-8", timeout: 5000 });
+    if (result.status === 0 && result.stdout) {
+      const cmdPath = result.stdout.trim().split(/\r?\n/)[0];
+      if (cmdPath && fs.existsSync(cmdPath)) {
+        const content = fs.readFileSync(cmdPath, "utf-8");
+        const match = content.match(/"%_prog%"\s+"([^"]+)"\s+%\*/);
+        if (match) {
+          let entryPath = match[1].replace(/%dp0%\\/gi, "").replace(/%dp0%/gi, "");
+          const fullPath = path.resolve(path.dirname(cmdPath), entryPath);
+          if (fs.existsSync(fullPath)) {
+            const nodeResult = spawnSync("where", ["node"], { encoding: "utf-8", timeout: 5000 });
+            const nodePath = nodeResult.stdout?.trim().split(/\r?\n/)[0] || "node";
+            return { command: nodePath, args: [fullPath] };
+          }
+        }
+      }
+    }
+  }
+  return { command: "gsd", args: [] };
+}
+
+const events = [];
+let startTime = null;
+let lastEventTime = null;
+let requestId = 0;
+let promptSentTime = null;
+
+function elapsed() { return startTime ? Date.now() - startTime : 0; }
+function gap() { return lastEventTime ? Date.now() - lastEventTime : 0; }
+
+const resolved = resolveGsd();
+console.log(`\n🔧 Spawning GSD RPC for subagent test`);
+console.log(`   ${resolved.command} ${resolved.args.join(" ")} --mode rpc\n`);
+
+const cleanEnv = {};
+for (const [key, value] of Object.entries(process.env)) {
+  if (key.startsWith("VSCODE_") || key.startsWith("ELECTRON_") || key === "NODE_OPTIONS") continue;
+  cleanEnv[key] = value;
+}
+cleanEnv.NO_COLOR = "1";
+cleanEnv.FORCE_COLOR = "0";
+
+const proc = spawn(resolved.command, [...resolved.args, "--mode", "rpc"], {
+  cwd: process.cwd(),
+  env: cleanEnv,
+  stdio: ["pipe", "pipe", "pipe"],
+  windowsHide: true,
+});
+
+console.log(`   PID: ${proc.pid}\n`);
+
+let buffer = "";
+proc.stdout.on("data", (chunk) => {
+  const now = Date.now();
+  const chunkStr = chunk.toString("utf-8");
+  buffer += chunkStr;
+
+  while (true) {
+    const idx = buffer.indexOf("\n");
+    if (idx === -1) break;
+    let line = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 1);
+    if (line.endsWith("\r")) line = line.slice(0, -1);
+    if (!line.trim()) continue;
+
+    try {
+      const msg = JSON.parse(line);
+      const eventType = msg.type || "unknown";
+      if (!startTime) startTime = now;
+
+      const sincePrompt = promptSentTime ? now - promptSentTime : 0;
+      const record = {
+        t: now,
+        elapsed: elapsed(),
+        gap: gap(),
+        sincePrompt,
+        type: eventType,
+        toolName: msg.toolName || undefined,
+        toolCallId: msg.toolCallId ? "…" + msg.toolCallId.slice(-6) : undefined,
+        partialLen: msg.partialResult?.content?.[0]?.text?.length || undefined,
+      };
+      events.push(record);
+      lastEventTime = now;
+
+      // Only log tool events and structural events, skip message_update spam
+      const isInteresting = [
+        "agent_start", "agent_end", "turn_start", "turn_end",
+        "tool_execution_start", "tool_execution_update", "tool_execution_end",
+        "response", "message_start", "message_end",
+      ].includes(eventType);
+
+      if (isInteresting) {
+        const parts = [`+${String(record.sincePrompt).padStart(7)}ms`];
+        if (record.gap > 2000) parts.push(`⚠️GAP=${(record.gap/1000).toFixed(1)}s`);
+        parts.push(eventType);
+        if (record.toolName) parts.push(`tool=${record.toolName}`);
+        if (record.toolCallId) parts.push(`id=${record.toolCallId}`);
+        if (record.partialLen) parts.push(`partial=${record.partialLen}ch`);
+        if (eventType === "response") parts.push(`cmd=${msg.command} ok=${msg.success}`);
+        console.log(`  ${parts.join("  ")}`);
+      }
+    } catch { /* not JSON */ }
+  }
+});
+
+proc.stderr.on("data", (chunk) => {
+  const text = chunk.toString("utf-8").trim();
+  if (text && !text.includes("[gsd] Extension load error")) {
+    console.log(`   [stderr] ${text.split("\n")[0]}`);
+  }
+});
+
+proc.on("exit", (code, signal) => {
+  console.log(`\n📊 Process exited: code=${code} signal=${signal}`);
+  printSummary();
+  process.exit(0);
+});
+
+function send(obj) {
+  const id = `diag-${++requestId}`;
+  proc.stdin.write(JSON.stringify({ ...obj, id }) + "\n");
+  return id;
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+function printSummary() {
+  console.log("\n" + "=".repeat(70));
+  console.log("SUBAGENT STREAMING DIAGNOSTIC SUMMARY");
+  console.log("=".repeat(70));
+
+  const toolUpdates = events.filter(e => e.type === "tool_execution_update");
+  const toolStarts = events.filter(e => e.type === "tool_execution_start");
+  const toolEnds = events.filter(e => e.type === "tool_execution_end");
+  const allGaps = events.map(e => e.gap).filter(g => g > 0);
+  const maxGap = Math.max(0, ...allGaps);
+
+  console.log(`Total events:          ${events.length}`);
+  console.log(`Tool starts:           ${toolStarts.length}`);
+  console.log(`Tool updates:          ${toolUpdates.length}`);
+  console.log(`Tool ends:             ${toolEnds.length}`);
+  console.log(`Max gap:               ${(maxGap / 1000).toFixed(1)}s`);
+
+  if (toolStarts.length > 0) {
+    console.log("\nPer-tool:");
+    for (const start of toolStarts) {
+      const end = toolEnds.find(e => e.toolCallId === start.toolCallId);
+      const updates = toolUpdates.filter(e => e.toolCallId === start.toolCallId);
+      const duration = end ? end.t - start.t : "still running";
+      console.log(`  ${start.toolName} (${start.toolCallId}): ${typeof duration === "number" ? `${(duration/1000).toFixed(1)}s` : duration}, ${updates.length} updates`);
+      if (updates.length > 0) {
+        const gaps = updates.map(u => u.gap);
+        console.log(`    Update gaps: min=${(Math.min(...gaps)/1000).toFixed(1)}s max=${(Math.max(...gaps)/1000).toFixed(1)}s`);
+      } else {
+        console.log(`    ⚠️ ZERO intermediate updates — results arrived as single dump`);
+      }
+    }
+  }
+
+  console.log("=".repeat(70));
+  const outPath = path.join(process.cwd(), "scripts", "rpc-subagent-results.json");
+  fs.writeFileSync(outPath, JSON.stringify(events, null, 2));
+  console.log(`Raw data: ${outPath}`);
+}
+
+// ── Test ──────────────────────────────────────────────────────────────
+
+async function run() {
+  await sleep(3000);
+
+  console.log("─".repeat(70));
+  console.log("TEST: Subagent tool — does it stream tool_execution_update events?");
+  console.log("Sending a prompt that triggers a subagent call...");
+  console.log("─".repeat(70));
+
+  promptSentTime = Date.now();
+
+  // This prompt should trigger the subagent tool to spawn a worker agent
+  send({
+    type: "prompt",
+    message: 'Use the subagent tool to delegate this task to the "worker" agent: "Read the file package.json in the current directory and tell me the version number and name of the project. That is all — just report the name and version."'
+  });
+
+  // Wait up to 90 seconds for the subagent to complete
+  let agentEnded = false;
+  const checkInterval = setInterval(() => {
+    if (events.some(e => e.type === "agent_end" && e.sincePrompt > 1000)) {
+      agentEnded = true;
+      clearInterval(checkInterval);
+    }
+  }, 1000);
+
+  for (let i = 0; i < 90; i++) {
+    await sleep(1000);
+    if (agentEnded) break;
+  }
+  clearInterval(checkInterval);
+
+  if (!agentEnded) {
+    console.log("\n⚠️  Agent did not complete within 90s — aborting");
+    send({ type: "abort" });
+    await sleep(3000);
+  }
+
+  console.log("\nShutting down...");
+  proc.kill("SIGTERM");
+  await sleep(2000);
+  try { proc.kill("SIGKILL"); } catch {}
+  printSummary();
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error("Diagnostic failed:", err);
+  proc.kill();
+  process.exit(1);
+});

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -48,6 +48,38 @@ const segmentElements = new Map<number, HTMLElement>();
 let _activeSegmentIndex = -1;
 let pendingTextRender: number | null = null;
 
+/**
+ * Live elapsed timer — refreshes running tool cards every second so the
+ * elapsed duration stays current. This gives the user a visible heartbeat
+ * that proves the extension is alive even when tools emit no partial updates.
+ */
+let elapsedTimerHandle: ReturnType<typeof setInterval> | null = null;
+
+function startElapsedTimer(): void {
+  if (elapsedTimerHandle) return;
+  elapsedTimerHandle = setInterval(() => {
+    if (!state.currentTurn) {
+      stopElapsedTimer();
+      return;
+    }
+    let anyRunning = false;
+    for (const [, tc] of state.currentTurn.toolCalls) {
+      if (tc.isRunning) {
+        anyRunning = true;
+        updateToolSegmentElement(tc.id);
+      }
+    }
+    if (!anyRunning) stopElapsedTimer();
+  }, 1000);
+}
+
+function stopElapsedTimer(): void {
+  if (elapsedTimerHandle) {
+    clearInterval(elapsedTimerHandle);
+    elapsedTimerHandle = null;
+  }
+}
+
 // ============================================================
 // Public API — entry rendering
 // ============================================================
@@ -119,6 +151,8 @@ export function appendToolSegmentElement(tc: ToolCallState, segIdx: number): voi
   el.innerHTML = buildToolCallHtml(tc);
   insertSegmentElement(container, segIdx, el);
   segmentElements.set(segIdx, el);
+  // Start live elapsed timer so running tools show a ticking duration
+  if (tc.isRunning) startElapsedTimer();
 }
 
 export function updateToolSegmentElement(toolCallId: string): void {
@@ -192,6 +226,8 @@ function tryStreamingCollapse(el: HTMLElement, segIdx: number): void {
 export function finalizeCurrentTurn(): void {
   if (!state.currentTurn) return;
 
+  stopElapsedTimer();
+
   if (pendingTextRender !== null) {
     cancelAnimationFrame(pendingTextRender);
     pendingTextRender = null;
@@ -227,6 +263,7 @@ export function resetStreamingState(): void {
   currentTurnElement = null;
   segmentElements.clear();
   _activeSegmentIndex = -1;
+  stopElapsedTimer();
 }
 
 // ============================================================
@@ -429,8 +466,14 @@ function buildToolCallHtml(tc: ToolCallState): string {
     tc.isError ? `<span class="gsd-tool-icon error">✗</span>` :
     `<span class="gsd-tool-icon success">✓</span>`;
 
-  const duration = tc.endTime && tc.startTime ? formatDuration(tc.endTime - tc.startTime) : "";
-  const durationHtml = duration ? `<span class="gsd-tool-duration">${duration}</span>` : "";
+  const duration = tc.endTime && tc.startTime
+    ? formatDuration(tc.endTime - tc.startTime)
+    : tc.isRunning && tc.startTime
+      ? formatDuration(Date.now() - tc.startTime)
+      : "";
+  const durationHtml = duration
+    ? `<span class="gsd-tool-duration${tc.isRunning ? " elapsed-live" : ""}">${duration}</span>`
+    : "";
 
   const stateClass = tc.isRunning ? "running" : tc.isError ? "error" : "done";
   const isSubagent = tc.name.toLowerCase() === "subagent";


### PR DESCRIPTION
## Root Cause Investigation

Built an automated RPC diagnostic harness (`scripts/rpc-streaming-diagnostic.mjs`) that spawns GSD in RPC mode, triggers tool execution, and measures event timing at the pipe level.

**Findings:**
- RPC pipeline streams correctly — bash tool updates arrive within 65ms, subagent updates every 3-5s per LLM turn
- Some extension tools (MCP/mcporter, async-jobs, mac-tools) don't implement the `onUpdate` callback, so they produce zero `tool_execution_update` events
- The perceived 'no streaming for 3-5 minutes' is actually correct tool behavior combined with a UI that showed static 'Running...' text with no elapsed time

## Changes

**Live elapsed timer** — running tool cards now show a ticking duration counter that updates every second. Gives the user visible proof of liveness even when tools emit no intermediate updates.

**Ping-based activity monitor** (from PR #9) — replaced the 120s event-based stall timeout with health pings. Long-running tools that don't emit events are no longer false-alarmed as hung.

**Removed client-side tool watchdog** (from PR #9) — 180s hard timeout removed. Hang detection is handled by the extension host ping monitor.

## Diagnostic Scripts
- `scripts/rpc-streaming-diagnostic.mjs` — general RPC event timing
- `scripts/rpc-subagent-diagnostic.mjs` — subagent-specific streaming test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added live elapsed timer displaying real-time duration updates for active tool calls, refreshing every second with improved visual feedback

* **Chores**
  * Introduced new diagnostic scripts for testing GSD RPC streaming capabilities and subagent event handling
  * Updated ignore patterns to exclude diagnostic result files from version control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->