### PR TITLE
M009: Dashboard Metrics & CLI Parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rokket-gsd",
 	"displayName": "Rokket GSD",
 	"description": "AI coding agent by Rokketek — full chat UI, tool execution, model picker, and GSD workflow automation in VS Code",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"publisher": "rokketek",
 	"license": "MIT",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rokket-gsd",
 	"displayName": "Rokket GSD",
 	"description": "AI coding agent by Rokketek — full chat UI, tool execution, model picker, and GSD workflow automation in VS Code",
-	"version": "0.2.26",
+	"version": "0.2.27",
 	"publisher": "rokketek",
 	"license": "MIT",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rokket-gsd",
 	"displayName": "Rokket GSD",
 	"description": "AI coding agent by Rokketek — full chat UI, tool execution, model picker, and GSD workflow automation in VS Code",
-	"version": "0.2.28",
+	"version": "0.2.29",
 	"publisher": "rokketek",
 	"license": "MIT",
 	"repository": {

--- a/src/extension/metrics-parser.test.ts
+++ b/src/extension/metrics-parser.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  classifyUnitPhase,
+  aggregateByPhase,
+  aggregateBySlice,
+  aggregateByModel,
+  getProjectTotals,
+  computeProjection,
+  buildMetricsData,
+  loadMetricsLedger,
+  formatCost,
+  formatDuration,
+  type UnitMetrics,
+  type MetricsLedger,
+} from "./metrics-parser";
+import * as fs from "fs";
+import * as path from "path";
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+
+function makeUnit(overrides: Partial<UnitMetrics> = {}): UnitMetrics {
+  return {
+    type: "execute-task",
+    id: "M001/S01/T01",
+    model: "claude-sonnet-4-6",
+    startedAt: 1000,
+    finishedAt: 61000, // 60s
+    tokens: { input: 5000, output: 2000, cacheRead: 1000, cacheWrite: 500, total: 8500 },
+    cost: 0.05,
+    toolCalls: 10,
+    assistantMessages: 3,
+    userMessages: 1,
+    ...overrides,
+  };
+}
+
+const sampleLedger: MetricsLedger = {
+  version: 1,
+  projectStartedAt: 1000,
+  units: [
+    makeUnit({ type: "research-milestone", id: "M001", model: "claude-sonnet-4-6", cost: 0.02 }),
+    makeUnit({ type: "plan-milestone", id: "M001", model: "claude-opus-4-6", cost: 0.10 }),
+    makeUnit({ type: "research-slice", id: "M001/S01", model: "claude-sonnet-4-6", cost: 0.03 }),
+    makeUnit({ type: "plan-slice", id: "M001/S01", model: "claude-opus-4-6", cost: 0.08 }),
+    makeUnit({ type: "execute-task", id: "M001/S01/T01", model: "claude-sonnet-4-6", cost: 0.05 }),
+    makeUnit({ type: "execute-task", id: "M001/S01/T02", model: "claude-sonnet-4-6", cost: 0.04 }),
+    makeUnit({ type: "complete-slice", id: "M001/S01", model: "claude-sonnet-4-6", cost: 0.02 }),
+    makeUnit({ type: "reassess-roadmap", id: "M001", model: "claude-sonnet-4-6", cost: 0.01 }),
+    makeUnit({ type: "execute-task", id: "M001/S02/T01", model: "claude-sonnet-4-6", cost: 0.06 }),
+    makeUnit({ type: "complete-slice", id: "M001/S02", model: "claude-sonnet-4-6", cost: 0.02 }),
+  ],
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("classifyUnitPhase", () => {
+  it("classifies research types", () => {
+    expect(classifyUnitPhase("research-milestone")).toBe("research");
+    expect(classifyUnitPhase("research-slice")).toBe("research");
+  });
+
+  it("classifies planning types", () => {
+    expect(classifyUnitPhase("plan-milestone")).toBe("planning");
+    expect(classifyUnitPhase("plan-slice")).toBe("planning");
+  });
+
+  it("classifies execution types", () => {
+    expect(classifyUnitPhase("execute-task")).toBe("execution");
+  });
+
+  it("classifies completion", () => {
+    expect(classifyUnitPhase("complete-slice")).toBe("completion");
+  });
+
+  it("classifies reassessment", () => {
+    expect(classifyUnitPhase("reassess-roadmap")).toBe("reassessment");
+  });
+
+  it("defaults unknown types to execution", () => {
+    expect(classifyUnitPhase("some-unknown")).toBe("execution");
+  });
+});
+
+describe("aggregateByPhase", () => {
+  it("groups units by phase in stable order", () => {
+    const result = aggregateByPhase(sampleLedger.units);
+    const phases = result.map(r => r.phase);
+    expect(phases).toEqual(["research", "planning", "execution", "completion", "reassessment"]);
+  });
+
+  it("counts units per phase correctly", () => {
+    const result = aggregateByPhase(sampleLedger.units);
+    const map = new Map(result.map(r => [r.phase, r]));
+    expect(map.get("research")!.units).toBe(2);
+    expect(map.get("planning")!.units).toBe(2);
+    expect(map.get("execution")!.units).toBe(3);
+    expect(map.get("completion")!.units).toBe(2);
+    expect(map.get("reassessment")!.units).toBe(1);
+  });
+
+  it("sums costs per phase", () => {
+    const result = aggregateByPhase(sampleLedger.units);
+    const map = new Map(result.map(r => [r.phase, r]));
+    expect(map.get("research")!.cost).toBeCloseTo(0.05);
+    expect(map.get("planning")!.cost).toBeCloseTo(0.18);
+    expect(map.get("execution")!.cost).toBeCloseTo(0.15);
+  });
+
+  it("returns empty array for empty units", () => {
+    expect(aggregateByPhase([])).toEqual([]);
+  });
+});
+
+describe("aggregateBySlice", () => {
+  it("groups by slice ID (M001/S01, M001/S02, etc.)", () => {
+    const result = aggregateBySlice(sampleLedger.units);
+    const ids = result.map(r => r.sliceId);
+    expect(ids).toContain("M001/S01");
+    expect(ids).toContain("M001/S02");
+  });
+
+  it("groups milestone-level entries under bare ID", () => {
+    const result = aggregateBySlice(sampleLedger.units);
+    const ids = result.map(r => r.sliceId);
+    expect(ids).toContain("M001");
+  });
+
+  it("returns sorted by sliceId", () => {
+    const result = aggregateBySlice(sampleLedger.units);
+    const ids = result.map(r => r.sliceId);
+    expect(ids).toEqual([...ids].sort());
+  });
+});
+
+describe("aggregateByModel", () => {
+  it("groups by model", () => {
+    const result = aggregateByModel(sampleLedger.units);
+    const models = result.map(r => r.model);
+    expect(models).toContain("claude-sonnet-4-6");
+    expect(models).toContain("claude-opus-4-6");
+  });
+
+  it("sorts by cost descending", () => {
+    const result = aggregateByModel(sampleLedger.units);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1].cost).toBeGreaterThanOrEqual(result[i].cost);
+    }
+  });
+});
+
+describe("getProjectTotals", () => {
+  it("sums all fields", () => {
+    const totals = getProjectTotals(sampleLedger.units);
+    expect(totals.units).toBe(10);
+    expect(totals.cost).toBeCloseTo(0.43);
+    expect(totals.tokens.input).toBe(50000);
+    expect(totals.toolCalls).toBe(100);
+  });
+
+  it("handles empty units", () => {
+    const totals = getProjectTotals([]);
+    expect(totals.units).toBe(0);
+    expect(totals.cost).toBe(0);
+    expect(totals.tokens.total).toBe(0);
+  });
+});
+
+describe("computeProjection", () => {
+  it("returns null with fewer than 2 completed slices", () => {
+    const slices = aggregateBySlice([makeUnit({ id: "M001/S01/T01" })]);
+    expect(computeProjection(slices, 3)).toBeNull();
+  });
+
+  it("returns null with 0 remaining slices", () => {
+    const slices = aggregateBySlice(sampleLedger.units);
+    expect(computeProjection(slices, 0)).toBeNull();
+  });
+
+  it("computes projection from completed slices", () => {
+    const slices = aggregateBySlice(sampleLedger.units);
+    const proj = computeProjection(slices, 3);
+    expect(proj).not.toBeNull();
+    expect(proj!.completedSlices).toBe(2); // M001/S01 and M001/S02
+    expect(proj!.remainingSlices).toBe(3);
+    expect(proj!.avgCostPerSlice).toBeGreaterThan(0);
+    expect(proj!.projectedRemaining).toBeCloseTo(proj!.avgCostPerSlice * 3);
+  });
+});
+
+describe("formatCost", () => {
+  it("formats tiny costs with 4 decimals", () => {
+    expect(formatCost(0.001)).toBe("$0.0010");
+  });
+
+  it("formats sub-dollar costs with 3 decimals", () => {
+    expect(formatCost(0.25)).toBe("$0.250");
+  });
+
+  it("formats dollar+ costs with 2 decimals", () => {
+    expect(formatCost(5.5)).toBe("$5.50");
+  });
+
+  it("handles zero", () => {
+    expect(formatCost(0)).toBe("$0.0000");
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats seconds", () => {
+    expect(formatDuration(45000)).toBe("45s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(125000)).toBe("2m 5s");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatDuration(3725000)).toBe("1h 2m");
+  });
+});
+
+describe("loadMetricsLedger", () => {
+  const tmpDir = path.join(__dirname, "../../.test-tmp-metrics");
+  const gsdDir = path.join(tmpDir, ".gsd");
+
+  beforeEach(() => {
+    fs.mkdirSync(gsdDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when file doesn't exist", () => {
+    expect(loadMetricsLedger(path.join(tmpDir, "nonexistent"))).toBeNull();
+  });
+
+  it("returns null for corrupt JSON", () => {
+    fs.writeFileSync(path.join(gsdDir, "metrics.json"), "not json{{{", "utf-8");
+    expect(loadMetricsLedger(tmpDir)).toBeNull();
+  });
+
+  it("returns null for wrong version", () => {
+    fs.writeFileSync(path.join(gsdDir, "metrics.json"), JSON.stringify({ version: 99, units: [] }), "utf-8");
+    expect(loadMetricsLedger(tmpDir)).toBeNull();
+  });
+
+  it("returns null when units is not an array", () => {
+    fs.writeFileSync(path.join(gsdDir, "metrics.json"), JSON.stringify({ version: 1, units: "bad" }), "utf-8");
+    expect(loadMetricsLedger(tmpDir)).toBeNull();
+  });
+
+  it("parses valid ledger", () => {
+    fs.writeFileSync(path.join(gsdDir, "metrics.json"), JSON.stringify(sampleLedger), "utf-8");
+    const result = loadMetricsLedger(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.units.length).toBe(10);
+    expect(result!.version).toBe(1);
+  });
+});
+
+describe("buildMetricsData", () => {
+  it("builds complete metrics data", () => {
+    const data = buildMetricsData(sampleLedger, 3);
+    expect(data.totals.units).toBe(10);
+    expect(data.byPhase.length).toBeGreaterThan(0);
+    expect(data.bySlice.length).toBeGreaterThan(0);
+    expect(data.byModel.length).toBeGreaterThan(0);
+    expect(data.projection).not.toBeNull();
+    expect(data.recentUnits.length).toBeLessThanOrEqual(15);
+    expect(data.elapsedMs).toBeGreaterThan(0);
+  });
+
+  it("returns recent units in reverse chronological order", () => {
+    const data = buildMetricsData(sampleLedger);
+    // Last unit in the ledger should be first in recentUnits
+    expect(data.recentUnits[0].id).toBe("M001/S02");
+  });
+
+  it("handles empty ledger", () => {
+    const empty: MetricsLedger = { version: 1, projectStartedAt: 0, units: [] };
+    const data = buildMetricsData(empty);
+    expect(data.totals.units).toBe(0);
+    expect(data.byPhase).toEqual([]);
+    expect(data.projection).toBeNull();
+  });
+});

--- a/src/extension/metrics-parser.test.ts
+++ b/src/extension/metrics-parser.test.ts
@@ -14,6 +14,7 @@ import {
   type MetricsLedger,
 } from "./metrics-parser";
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 
 // ─── Test fixtures ────────────────────────────────────────────────────────────
@@ -220,15 +221,17 @@ describe("formatDuration", () => {
 });
 
 describe("loadMetricsLedger", () => {
-  const tmpDir = path.join(__dirname, "../../.test-tmp-metrics");
-  const gsdDir = path.join(tmpDir, ".gsd");
+  let tmpDir: string;
+  let gsdDir: string;
 
   beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gsd-metrics-test-"));
+    gsdDir = path.join(tmpDir, ".gsd");
     fs.mkdirSync(gsdDir, { recursive: true });
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
   });
 
   it("returns null when file doesn't exist", () => {

--- a/src/extension/metrics-parser.test.ts
+++ b/src/extension/metrics-parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   classifyUnitPhase,
   aggregateByPhase,
@@ -231,7 +231,7 @@ describe("loadMetricsLedger", () => {
   });
 
   afterEach(() => {
-    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* cleanup */ }
   });
 
   it("returns null when file doesn't exist", () => {

--- a/src/extension/metrics-parser.ts
+++ b/src/extension/metrics-parser.ts
@@ -1,0 +1,292 @@
+/**
+ * Metrics Parser — reads .gsd/metrics.json and provides aggregated data
+ * for the dashboard. Mirrors the CLI's metrics.ts types and aggregation
+ * logic but runs in the VS Code extension host.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+// ─── Types (matching CLI's MetricsLedger schema) ─────────────────────────────
+
+export interface TokenCounts {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+}
+
+export interface UnitMetrics {
+  type: string;            // e.g. "research-milestone", "execute-task"
+  id: string;              // e.g. "M001/S01/T01"
+  model: string;           // model ID used
+  startedAt: number;       // ms timestamp
+  finishedAt: number;      // ms timestamp
+  tokens: TokenCounts;
+  cost: number;            // total USD cost
+  toolCalls: number;
+  assistantMessages: number;
+  userMessages: number;
+}
+
+export interface MetricsLedger {
+  version: 1;
+  projectStartedAt: number;
+  units: UnitMetrics[];
+}
+
+// ─── Phase classification ─────────────────────────────────────────────────────
+
+export type MetricsPhase = "research" | "planning" | "execution" | "completion" | "reassessment";
+
+export function classifyUnitPhase(unitType: string): MetricsPhase {
+  switch (unitType) {
+    case "research-milestone":
+    case "research-slice":
+      return "research";
+    case "plan-milestone":
+    case "plan-slice":
+      return "planning";
+    case "execute-task":
+      return "execution";
+    case "complete-slice":
+      return "completion";
+    case "reassess-roadmap":
+      return "reassessment";
+    default:
+      return "execution";
+  }
+}
+
+// ─── Aggregation types ────────────────────────────────────────────────────────
+
+export interface PhaseAggregate {
+  phase: MetricsPhase;
+  units: number;
+  tokens: TokenCounts;
+  cost: number;
+  duration: number;  // ms
+}
+
+export interface SliceAggregate {
+  sliceId: string;
+  units: number;
+  tokens: TokenCounts;
+  cost: number;
+  duration: number;
+}
+
+export interface ModelAggregate {
+  model: string;
+  units: number;
+  tokens: TokenCounts;
+  cost: number;
+}
+
+export interface ProjectTotals {
+  units: number;
+  tokens: TokenCounts;
+  cost: number;
+  duration: number;
+  toolCalls: number;
+  assistantMessages: number;
+  userMessages: number;
+}
+
+export interface CostProjection {
+  projectedRemaining: number;
+  avgCostPerSlice: number;
+  remainingSlices: number;
+  completedSlices: number;
+}
+
+export interface MetricsData {
+  totals: ProjectTotals;
+  byPhase: PhaseAggregate[];
+  bySlice: SliceAggregate[];
+  byModel: ModelAggregate[];
+  projection: CostProjection | null;
+  recentUnits: UnitMetrics[];  // last N units for activity log
+  elapsedMs: number;           // total duration across all units
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function emptyTokens(): TokenCounts {
+  return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+}
+
+function addTokens(a: TokenCounts, b: TokenCounts): TokenCounts {
+  return {
+    input: a.input + b.input,
+    output: a.output + b.output,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheWrite: a.cacheWrite + b.cacheWrite,
+    total: a.total + b.total,
+  };
+}
+
+// ─── Aggregation functions ────────────────────────────────────────────────────
+
+export function aggregateByPhase(units: UnitMetrics[]): PhaseAggregate[] {
+  const map = new Map<MetricsPhase, PhaseAggregate>();
+  for (const u of units) {
+    const phase = classifyUnitPhase(u.type);
+    let agg = map.get(phase);
+    if (!agg) {
+      agg = { phase, units: 0, tokens: emptyTokens(), cost: 0, duration: 0 };
+      map.set(phase, agg);
+    }
+    agg.units++;
+    agg.tokens = addTokens(agg.tokens, u.tokens);
+    agg.cost += u.cost;
+    agg.duration += (u.finishedAt || 0) - (u.startedAt || 0);
+  }
+  const order: MetricsPhase[] = ["research", "planning", "execution", "completion", "reassessment"];
+  return order.map(p => map.get(p)).filter((a): a is PhaseAggregate => !!a);
+}
+
+export function aggregateBySlice(units: UnitMetrics[]): SliceAggregate[] {
+  const map = new Map<string, SliceAggregate>();
+  for (const u of units) {
+    const parts = u.id.split("/");
+    const sliceId = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : parts[0];
+    let agg = map.get(sliceId);
+    if (!agg) {
+      agg = { sliceId, units: 0, tokens: emptyTokens(), cost: 0, duration: 0 };
+      map.set(sliceId, agg);
+    }
+    agg.units++;
+    agg.tokens = addTokens(agg.tokens, u.tokens);
+    agg.cost += u.cost;
+    agg.duration += (u.finishedAt || 0) - (u.startedAt || 0);
+  }
+  return Array.from(map.values()).sort((a, b) => a.sliceId.localeCompare(b.sliceId));
+}
+
+export function aggregateByModel(units: UnitMetrics[]): ModelAggregate[] {
+  const map = new Map<string, ModelAggregate>();
+  for (const u of units) {
+    const model = u.model || "unknown";
+    let agg = map.get(model);
+    if (!agg) {
+      agg = { model, units: 0, tokens: emptyTokens(), cost: 0 };
+      map.set(model, agg);
+    }
+    agg.units++;
+    agg.tokens = addTokens(agg.tokens, u.tokens);
+    agg.cost += u.cost;
+  }
+  return Array.from(map.values()).sort((a, b) => b.cost - a.cost);
+}
+
+export function getProjectTotals(units: UnitMetrics[]): ProjectTotals {
+  const totals: ProjectTotals = {
+    units: units.length,
+    tokens: emptyTokens(),
+    cost: 0,
+    duration: 0,
+    toolCalls: 0,
+    assistantMessages: 0,
+    userMessages: 0,
+  };
+  for (const u of units) {
+    totals.tokens = addTokens(totals.tokens, u.tokens);
+    totals.cost += u.cost;
+    totals.duration += (u.finishedAt || 0) - (u.startedAt || 0);
+    totals.toolCalls += u.toolCalls || 0;
+    totals.assistantMessages += u.assistantMessages || 0;
+    totals.userMessages += u.userMessages || 0;
+  }
+  return totals;
+}
+
+export function computeProjection(
+  sliceAggregates: SliceAggregate[],
+  remainingSliceCount: number,
+): CostProjection | null {
+  // Need at least 2 completed slices for a meaningful projection
+  const completed = sliceAggregates.filter(s => s.sliceId.includes("/"));
+  if (completed.length < 2 || remainingSliceCount <= 0) return null;
+
+  const totalCost = completed.reduce((sum, s) => sum + s.cost, 0);
+  const avgCost = totalCost / completed.length;
+
+  return {
+    projectedRemaining: avgCost * remainingSliceCount,
+    avgCostPerSlice: avgCost,
+    remainingSlices: remainingSliceCount,
+    completedSlices: completed.length,
+  };
+}
+
+// ─── Formatting helpers ───────────────────────────────────────────────────────
+
+export function formatCost(cost: number): string {
+  const n = Number(cost) || 0;
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 1) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+export function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rs = s % 60;
+  if (m < 60) return `${m}m ${rs}s`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return `${h}h ${rm}m`;
+}
+
+// ─── File I/O ─────────────────────────────────────────────────────────────────
+
+/**
+ * Load and parse .gsd/metrics.json from a project directory.
+ * Returns null if the file doesn't exist, is malformed, or has an unexpected version.
+ */
+export function loadMetricsLedger(cwd: string): MetricsLedger | null {
+  const metricsPath = path.join(cwd, ".gsd", "metrics.json");
+  try {
+    const raw = fs.readFileSync(metricsPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.version === 1 && Array.isArray(parsed.units)) {
+      return parsed as MetricsLedger;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build full metrics data from a ledger, ready for dashboard rendering.
+ * Pass remainingSliceCount for cost projection (0 if unknown).
+ */
+export function buildMetricsData(
+  ledger: MetricsLedger,
+  remainingSliceCount: number = 0,
+  maxRecentUnits: number = 15,
+): MetricsData {
+  const units = ledger.units;
+  const totals = getProjectTotals(units);
+  const byPhase = aggregateByPhase(units);
+  const bySlice = aggregateBySlice(units);
+  const byModel = aggregateByModel(units);
+  const projection = computeProjection(bySlice, remainingSliceCount);
+
+  // Most recent units first
+  const recentUnits = units.slice().reverse().slice(0, maxRecentUnits);
+
+  return {
+    totals,
+    byPhase,
+    bySlice,
+    byModel,
+    projection,
+    recentUnits,
+    elapsedMs: totals.duration,
+  };
+}

--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -47,6 +47,8 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
   private slashWatchdogs: Map<string, ReturnType<typeof setTimeout>> = new Map();
   /** Tracks per-session timestamp of last RPC event received — used by slash command watchdog */
   private lastEventTime: Map<string, number> = new Map();
+  /** Per-session launch promises — prevents concurrent launchGsd calls from racing */
+  private launchPromises: Map<string, Promise<void>> = new Map();
   /** Streaming activity monitor — detects stalled agent turns and auto-recovers */
   private activityTimers: Map<string, ReturnType<typeof setInterval>> = new Map();
   private isSessionStreaming: Map<string, boolean> = new Map();
@@ -319,18 +321,12 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
         watchdog.retried = true;
 
         try {
-          await client.prompt(message, images);
-          // Re-check nonce after await — a new prompt may have started during the retry
-          const current = this.promptWatchdogs.get(sessionId);
-          if (!current || current.nonce !== nonce) return;
-
-          // Restart watchdog for the retry
+          // Start the final-chance watchdog BEFORE awaiting — if prompt()
+          // hangs, we still need the timer to fire.
           watchdog.timer = setTimeout(() => {
-            // Verify nonce is still current before acting
             const finalCheck = this.promptWatchdogs.get(sessionId);
             if (!finalCheck || finalCheck.nonce !== nonce) return;
 
-            // Second timeout — give up
             this.output.appendLine(`[${sessionId}] Prompt watchdog: retry also got no response — notifying user`);
             this.clearPromptWatchdog(sessionId);
             this.postToWebview(webview, {
@@ -338,6 +334,11 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
               message: "GSD accepted the command but didn't start processing. Try sending it again.",
             } as ExtensionToWebviewMessage);
           }, WATCHDOG_TIMEOUT_MS);
+
+          await client.prompt(message, images);
+          // Re-check nonce after await — a new prompt may have started during the retry
+          const current = this.promptWatchdogs.get(sessionId);
+          if (!current || current.nonce !== nonce) return;
         } catch (err: any) {
           this.output.appendLine(`[${sessionId}] Prompt watchdog: retry failed — ${err.message}`);
           // Only clear if this watchdog is still current
@@ -395,9 +396,9 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
       // Retry once
       this.output.appendLine(`[${sessionId}] Slash watchdog: no events after ${TIMEOUT_MS / 1000}s for "${message}" — retrying`);
       try {
-        await client.prompt(message, images);
         const retrySentAt = Date.now();
-        // Set a second watchdog for the retry
+        // Start the final-chance watchdog BEFORE awaiting — if prompt()
+        // hangs, we still need the timer to fire.
         const retryTimer = setTimeout(() => {
           this.slashWatchdogs.delete(sessionId);
           const lastRetryEvent = this.lastEventTime.get(sessionId) || 0;
@@ -410,6 +411,8 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
           } as ExtensionToWebviewMessage);
         }, TIMEOUT_MS);
         this.slashWatchdogs.set(sessionId, retryTimer);
+
+        await client.prompt(message, images);
       } catch (err: any) {
         this.postToWebview(webview, { type: "error", message: err.message });
       }
@@ -787,15 +790,14 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
                 data: img.data,
                 mimeType: img.mimeType,
               }));
-              await c.prompt(msg.message, images);
-              // Slash commands don't emit agent_start (handled by pi extensions),
-              // so the regular watchdog would false-alarm. Instead, start a
-              // slash-command watchdog that just checks if ANY event arrived.
+              // Start watchdog BEFORE awaiting prompt — if pi never acks the
+              // RPC the await hangs forever and the watchdog would never start.
               if (msg.message.startsWith("/")) {
                 this.startSlashCommandWatchdog(webview, sessionId, msg.message, images);
               } else {
                 this.startPromptWatchdog(webview, sessionId, msg.message, images);
               }
+              await c.prompt(msg.message, images);
             } catch (err: any) {
               if (err.message?.includes("streaming")) {
                 const isSlash = msg.message.trimStart().startsWith("/");
@@ -806,8 +808,8 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
                     mimeType: img.mimeType,
                   }));
                   if (isSlash) {
-                    await this.abortAndPrompt(c, webview, msg.message, msg.images);
                     this.startSlashCommandWatchdog(webview, sessionId, msg.message, imgs);
+                    await this.abortAndPrompt(c, webview, msg.message, msg.images);
                   } else {
                     await c.steer(msg.message, imgs);
                   }
@@ -1501,7 +1503,21 @@ ${exportOverrides}
 
   // --- GSD Process Management ---
 
-  private async launchGsd(webview: vscode.Webview, sessionId: string, cwd?: string): Promise<void> {
+  private launchGsd(webview: vscode.Webview, sessionId: string, cwd?: string): Promise<void> {
+    // Deduplicate concurrent launches for the same session — if a launch is
+    // already in progress (e.g. webview sent launch_gsd and then an immediate
+    // prompt), piggyback on the existing promise instead of spawning a second process.
+    const existing = this.launchPromises.get(sessionId);
+    if (existing) return existing;
+
+    const promise = this._doLaunchGsd(webview, sessionId, cwd).finally(() => {
+      this.launchPromises.delete(sessionId);
+    });
+    this.launchPromises.set(sessionId, promise);
+    return promise;
+  }
+
+  private async _doLaunchGsd(webview: vscode.Webview, sessionId: string, cwd?: string): Promise<void> {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     const workingDir = cwd || workspaceFolders?.[0]?.uri.fsPath || process.cwd();
 

--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -1560,7 +1560,9 @@ ${exportOverrides}
     client.on("exit", ({ code, signal, detail }: { code: number | null; signal: string | null; detail?: string }) => {
       this.output.appendLine(`[${sessionId}] Process exited: ${detail || `code=${code}, signal=${signal}`}`);
       this.postToWebview(webview, { type: "process_exit", code, signal, detail });
-      this.postToWebview(webview, { type: "process_status", status: "crashed" } as ExtensionToWebviewMessage);
+      // Clean exit (code 0 or SIGTERM/SIGKILL) → stopped; anything else → crashed
+      const isCleanExit = code === 0 || signal === "SIGTERM" || signal === "SIGKILL";
+      this.postToWebview(webview, { type: "process_status", status: isCleanExit ? "stopped" : "crashed" } as ExtensionToWebviewMessage);
 
       // Stop all monitoring timers and watchdogs
       const timer = this.statsTimers.get(sessionId);
@@ -1590,10 +1592,10 @@ ${exportOverrides}
       }
       this.lastEventTime.delete(sessionId);
 
-      if (signal !== "SIGTERM" && signal !== "SIGKILL") {
-        this.output.appendLine(`[${sessionId}] Unexpected exit — will auto-restart on next prompt`);
-      } else {
+      if (isCleanExit) {
         this.rpcClients.delete(sessionId);
+      } else {
+        this.output.appendLine(`[${sessionId}] Unexpected exit — will auto-restart on next prompt`);
       }
     });
 

--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -7,6 +7,7 @@ import { listSessions, deleteSession } from "./session-list-service";
 import { downloadAndInstallUpdate, dismissUpdateVersion, fetchReleaseNotes, fetchRecentReleases } from "./update-checker";
 import { parseGsdWorkflowState } from "./state-parser";
 import { buildDashboardData } from "./dashboard-parser";
+import { loadMetricsLedger, buildMetricsData } from "./metrics-parser";
 import type {
   WebviewToExtensionMessage,
   ExtensionToWebviewMessage,
@@ -955,6 +956,19 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
                 } catch {
                   // Stats not available — that's fine
                 }
+              }
+            }
+            // Merge metrics data if available
+            if (data) {
+              try {
+                const ledger = loadMetricsLedger(cwd);
+                if (ledger && ledger.units.length > 0) {
+                  // Count remaining slices from roadmap
+                  const remainingSlices = data.slices.filter(s => !s.done).length;
+                  data.metrics = buildMetricsData(ledger, remainingSlices);
+                }
+              } catch {
+                // Metrics not available — that's fine
               }
             }
             this.postToWebview(webview, { type: "dashboard_data", data } as ExtensionToWebviewMessage);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -304,6 +304,58 @@ export interface DashboardData {
     toolCalls?: number;
     userMessages?: number;
   };
+  /** Per-unit metrics from .gsd/metrics.json — null when file doesn't exist */
+  metrics?: DashboardMetrics | null;
+}
+
+// --- Metrics data for dashboard (from metrics.json) ---
+
+export interface DashboardMetrics {
+  totals: {
+    units: number;
+    tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+    cost: number;
+    duration: number;
+    toolCalls: number;
+    assistantMessages: number;
+    userMessages: number;
+  };
+  byPhase: Array<{
+    phase: string;
+    units: number;
+    tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+    cost: number;
+    duration: number;
+  }>;
+  bySlice: Array<{
+    sliceId: string;
+    units: number;
+    tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+    cost: number;
+    duration: number;
+  }>;
+  byModel: Array<{
+    model: string;
+    units: number;
+    tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+    cost: number;
+  }>;
+  projection: {
+    projectedRemaining: number;
+    avgCostPerSlice: number;
+    remainingSlices: number;
+    completedSlices: number;
+  } | null;
+  recentUnits: Array<{
+    type: string;
+    id: string;
+    model: string;
+    startedAt: number;
+    finishedAt: number;
+    cost: number;
+    toolCalls: number;
+  }>;
+  elapsedMs: number;
 }
 
 // --- Workflow State (parsed from .gsd/STATE.md) ---

--- a/src/webview/dashboard.ts
+++ b/src/webview/dashboard.ts
@@ -2,7 +2,7 @@
 // Dashboard Panel — renders GSD project status dashboard
 // ============================================================
 
-import type { DashboardData, DashboardSlice } from "../shared/types";
+import type { DashboardData, DashboardSlice, DashboardMetrics } from "../shared/types";
 import { escapeHtml, scrollToBottom } from "./helpers";
 import { state } from "./state";
 
@@ -247,7 +247,7 @@ export function renderDashboard(data: DashboardData | null): void {
 
     ${milestoneList(data.milestoneRegistry)}
     ${blockersSection(data.blockers)}
-    ${costSection(data.stats)}
+    ${data.metrics ? metricsSection(data.metrics) : costSection(data.stats)}
     ${nextActionSection(data.nextAction)}
 
     <div class="gsd-dashboard-footer">
@@ -257,6 +257,157 @@ export function renderDashboard(data: DashboardData | null): void {
 
   messagesContainer.appendChild(el);
   scrollToBottom(messagesContainer, true);
+}
+
+// ============================================================
+// Metrics rendering (from .gsd/metrics.json)
+// ============================================================
+
+function metricsSection(m: DashboardMetrics): string {
+  const parts: string[] = [];
+
+  // Totals summary
+  const summaryItems: string[] = [];
+  if (m.totals.cost > 0) summaryItems.push(`<span class="gsd-dash-cost-value">${fmtCost(m.totals.cost)}</span> total`);
+  if (m.totals.tokens.total > 0) summaryItems.push(`${formatTokenCount(m.totals.tokens.total)} tokens`);
+  if (m.totals.toolCalls > 0) summaryItems.push(`${m.totals.toolCalls} tools`);
+  if (m.totals.units > 0) summaryItems.push(`${m.totals.units} units`);
+  if (m.elapsedMs > 0) summaryItems.push(`${fmtDuration(m.elapsedMs)} elapsed`);
+
+  parts.push(`
+    <div class="gsd-dash-section">
+      <div class="gsd-dash-section-title">Cost & Usage</div>
+      <div class="gsd-dash-cost-summary">${summaryItems.join("  ·  ")}</div>
+    </div>
+  `);
+
+  // Projection
+  if (m.projection) {
+    parts.push(`
+      <div class="gsd-dash-section gsd-dash-projection">
+        <div class="gsd-dash-projection-line">Projected remaining: <strong>${fmtCost(m.projection.projectedRemaining)}</strong> (${fmtCost(m.projection.avgCostPerSlice)}/slice avg × ${m.projection.remainingSlices} remaining)</div>
+      </div>
+    `);
+  }
+
+  // Phase breakdown
+  if (m.byPhase.length > 0) {
+    parts.push(breakdownTable("By Phase", m.byPhase.map(p => ({
+      label: p.phase.charAt(0).toUpperCase() + p.phase.slice(1),
+      cost: p.cost,
+      tokens: p.tokens.total,
+      units: p.units,
+      duration: p.duration,
+    }))));
+  }
+
+  // Slice breakdown
+  if (m.bySlice.length > 0) {
+    parts.push(breakdownTable("By Slice", m.bySlice.map(s => ({
+      label: s.sliceId,
+      cost: s.cost,
+      tokens: s.tokens.total,
+      units: s.units,
+      duration: s.duration,
+    }))));
+  }
+
+  // Model breakdown
+  if (m.byModel.length > 0) {
+    parts.push(breakdownTable("By Model", m.byModel.map(mo => ({
+      label: mo.model.replace(/^.*\//, ""), // strip provider prefix
+      cost: mo.cost,
+      tokens: mo.tokens.total,
+      units: mo.units,
+    }))));
+  }
+
+  // Activity log
+  if (m.recentUnits.length > 0) {
+    const rows = m.recentUnits.map(u => {
+      const dur = u.finishedAt - u.startedAt;
+      return `<div class="gsd-dash-activity-row">
+        <span class="gsd-dash-activity-type">${escapeHtml(u.type.replace(/-/g, " "))}</span>
+        <span class="gsd-dash-activity-id">${escapeHtml(u.id)}</span>
+        <span class="gsd-dash-activity-cost">${fmtCost(u.cost)}</span>
+        <span class="gsd-dash-activity-dur">${fmtDuration(dur)}</span>
+      </div>`;
+    }).join("");
+
+    parts.push(`
+      <div class="gsd-dash-section">
+        <div class="gsd-dash-section-title">Activity Log</div>
+        <div class="gsd-dash-activity${m.recentUnits.length > 10 ? " gsd-dash-activity-scroll" : ""}">${rows}</div>
+      </div>
+    `);
+  }
+
+  return parts.join("");
+}
+
+interface BreakdownRow {
+  label: string;
+  cost: number;
+  tokens: number;
+  units: number;
+  duration?: number;
+}
+
+function breakdownTable(title: string, rows: BreakdownRow[]): string {
+  // Compact mode: ≤2 rows collapse to inline
+  if (rows.length <= 2) {
+    const inline = rows.map(r =>
+      `<span class="gsd-dash-inline-breakdown">${escapeHtml(r.label)}: ${fmtCost(r.cost)}</span>`
+    ).join("  ·  ");
+    return `
+      <div class="gsd-dash-section">
+        <div class="gsd-dash-section-title">${escapeHtml(title)}</div>
+        <div class="gsd-dash-cost-summary">${inline}</div>
+      </div>
+    `;
+  }
+
+  const tableRows = rows.map(r => `
+    <tr>
+      <td>${escapeHtml(r.label)}</td>
+      <td class="gsd-dash-num">${fmtCost(r.cost)}</td>
+      <td class="gsd-dash-num">${formatTokenCount(r.tokens)}</td>
+      <td class="gsd-dash-num">${r.units}</td>
+      ${r.duration != null ? `<td class="gsd-dash-num">${fmtDuration(r.duration)}</td>` : ""}
+    </tr>
+  `).join("");
+
+  const hasDuration = rows.some(r => r.duration != null);
+  return `
+    <div class="gsd-dash-section">
+      <div class="gsd-dash-section-title">${escapeHtml(title)}</div>
+      <table class="gsd-dash-table">
+        <thead><tr>
+          <th></th><th>Cost</th><th>Tokens</th><th>Units</th>
+          ${hasDuration ? "<th>Time</th>" : ""}
+        </tr></thead>
+        <tbody>${tableRows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+function fmtCost(cost: number): string {
+  const n = Number(cost) || 0;
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 1) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function fmtDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rs = s % 60;
+  if (m < 60) return `${m}m ${rs}s`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return `${h}h ${rm}m`;
 }
 
 export function formatTokenCount(n: number): string {

--- a/src/webview/helpers.ts
+++ b/src/webview/helpers.ts
@@ -217,12 +217,126 @@ export function formatToolResult(toolName: string, resultText: string, args: Rec
   return resultText;
 }
 
+// ============================================================
+// Subagent formatting helpers
+// ============================================================
+
+function formatTokenCount(count: number): string {
+  if (count < 1000) return count.toString();
+  if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
+  if (count < 1000000) return `${Math.round(count / 1000)}k`;
+  return `${(count / 1000000).toFixed(1)}M`;
+}
+
+function buildUsagePills(usage: any, model?: string): string {
+  if (!usage) return "";
+  const pills: string[] = [];
+  if (usage.turns) pills.push(`${usage.turns} turn${usage.turns > 1 ? "s" : ""}`);
+  if (usage.input) pills.push(`↑${formatTokenCount(usage.input)}`);
+  if (usage.output) pills.push(`↓${formatTokenCount(usage.output)}`);
+  if (usage.cost) pills.push(`$${(Number(usage.cost) || 0).toFixed(4)}`);
+  if (model) pills.push(model);
+  if (pills.length === 0) return "";
+  return `<div class="gsd-agent-usage">${pills.map(p => `<span class="gsd-agent-pill">${escapeHtml(p)}</span>`).join("")}</div>`;
+}
+
+function buildAgentCard(r: any, isRunning: boolean): string {
+  const running = r.exitCode === -1;
+  const failed = !running && (r.exitCode !== 0 || r.stopReason === "error" || r.stopReason === "aborted");
+  const done = !running && !failed;
+
+  const stateClass = running ? "running" : failed ? "error" : "done";
+  const icon = running
+    ? `<span class="gsd-tool-spinner"></span>`
+    : failed
+      ? `<span class="gsd-agent-icon error">✗</span>`
+      : `<span class="gsd-agent-icon done">✓</span>`;
+
+  const taskPreview = r.task
+    ? (r.task.length > 120 ? r.task.slice(0, 120) + "…" : r.task)
+    : "";
+
+  let html = `<div class="gsd-agent-card ${stateClass}">`;
+  html += `<div class="gsd-agent-header">`;
+  html += `<div class="gsd-agent-header-left">${icon}<span class="gsd-agent-name">${escapeHtml(r.agent)}</span></div>`;
+  html += buildUsagePills(r.usage, r.model);
+  html += `</div>`;
+
+  if (taskPreview) {
+    html += `<div class="gsd-agent-task">${escapeHtml(taskPreview)}</div>`;
+  }
+
+  if (failed && r.errorMessage) {
+    html += `<div class="gsd-agent-error">${escapeHtml(r.errorMessage)}</div>`;
+  }
+
+  html += `</div>`;
+  return html;
+}
+
 /** Build rich HTML for subagent results instead of plain text */
 export function buildSubagentOutputHtml(tc: ToolCallState): string {
   const text = tc.resultText;
   const args = tc.args;
-  const mode = args.chain ? "chain" : args.tasks ? "parallel" : "single";
+  const details = tc.details as { mode?: string; results?: any[] } | undefined;
+  const mode = details?.mode || (args.chain ? "chain" : args.tasks ? "parallel" : "single");
+  const results = details?.results;
 
+  // If we have structured details with per-agent results, render cards
+  if (results && results.length > 0) {
+    const running = results.filter((r: any) => r.exitCode === -1).length;
+    const done = results.filter((r: any) => r.exitCode !== -1 && r.exitCode === 0).length;
+    const failed = results.filter((r: any) => r.exitCode > 0 || r.stopReason === "error").length;
+    const total = results.length;
+
+    let html = `<div class="gsd-subagent-panel">`;
+
+    // Summary bar
+    const modeLabel = mode === "chain" ? "Chain" : mode === "parallel" ? "Parallel" : "Agent";
+    let statusParts: string[] = [];
+    if (done > 0) statusParts.push(`<span class="gsd-agent-stat done">${done} done</span>`);
+    if (running > 0) statusParts.push(`<span class="gsd-agent-stat running">${running} running</span>`);
+    if (failed > 0) statusParts.push(`<span class="gsd-agent-stat error">${failed} failed</span>`);
+    html += `<div class="gsd-subagent-summary">`;
+    html += `<span class="gsd-subagent-mode">${escapeHtml(modeLabel)}</span>`;
+    html += `<span class="gsd-subagent-counts">${statusParts.join(`<span class="gsd-agent-sep">·</span>`)}</span>`;
+    html += `<span class="gsd-subagent-total">${done + failed}/${total}</span>`;
+    html += `</div>`;
+
+    // Agent cards
+    html += `<div class="gsd-agent-cards">`;
+    for (const r of results) {
+      html += buildAgentCard(r, tc.isRunning);
+    }
+    html += `</div>`;
+
+    // Aggregate usage for completed runs
+    if (!tc.isRunning) {
+      const totalUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
+      for (const r of results) {
+        if (r.usage) {
+          totalUsage.input += r.usage.input || 0;
+          totalUsage.output += r.usage.output || 0;
+          totalUsage.cost += r.usage.cost || 0;
+          totalUsage.turns += r.usage.turns || 0;
+        }
+      }
+      if (totalUsage.turns > 0) {
+        html += `<div class="gsd-subagent-footer">${buildUsagePills(totalUsage)}</div>`;
+      }
+    }
+
+    html += `</div>`;
+
+    // If completed, also render the final output as markdown below
+    if (!tc.isRunning && text) {
+      html += `<div class="gsd-subagent-result">${renderMarkdown(text)}</div>`;
+    }
+
+    return html;
+  }
+
+  // Fallback: no structured details, use legacy rendering
   if (tc.isRunning) {
     const agentName = (args.agent as string) ||
                       (args.chain as any[])?.[0]?.agent ||

--- a/src/webview/helpers.ts
+++ b/src/webview/helpers.ts
@@ -240,10 +240,10 @@ function buildUsagePills(usage: any, model?: string): string {
   return `<div class="gsd-agent-usage">${pills.map(p => `<span class="gsd-agent-pill">${escapeHtml(p)}</span>`).join("")}</div>`;
 }
 
-function buildAgentCard(r: any, isRunning: boolean): string {
+function buildAgentCard(r: any, _isRunning: boolean): string {
   const running = r.exitCode === -1;
   const failed = !running && (r.exitCode !== 0 || r.stopReason === "error" || r.stopReason === "aborted");
-  const done = !running && !failed;
+  const _done = !running && !failed;
 
   const stateClass = running ? "running" : failed ? "error" : "done";
   const icon = running
@@ -293,7 +293,7 @@ export function buildSubagentOutputHtml(tc: ToolCallState): string {
 
     // Summary bar
     const modeLabel = mode === "chain" ? "Chain" : mode === "parallel" ? "Parallel" : "Agent";
-    let statusParts: string[] = [];
+    const statusParts: string[] = [];
     if (done > 0) statusParts.push(`<span class="gsd-agent-stat done">${done} done</span>`);
     if (running > 0) statusParts.push(`<span class="gsd-agent-stat running">${running} running</span>`);
     if (failed > 0) statusParts.push(`<span class="gsd-agent-stat error">${failed} failed</span>`);

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -342,6 +342,7 @@ function handleMessage(event: MessageEvent): void {
           .filter(Boolean)
           .join("\n");
         if (text) tc.resultText = text;
+        if (data.partialResult.details) tc.details = data.partialResult.details;
         renderer.updateToolSegmentElement(data.toolCallId);
         scrollToBottom(messagesContainer);
       }
@@ -367,6 +368,7 @@ function handleMessage(event: MessageEvent): void {
             .filter(Boolean)
             .join("\n");
           if (text) tc.resultText = text;
+          if (data.result.details) tc.details = data.result.details;
         }
       }
       renderer.updateToolSegmentElement(data.toolCallId);

--- a/src/webview/state.ts
+++ b/src/webview/state.ts
@@ -24,6 +24,8 @@ export interface ToolCallState {
   isRunning: boolean;
   startTime: number;
   endTime?: number;
+  /** Structured details from tool (e.g. subagent per-agent results) */
+  details?: any;
 }
 
 /** A segment in the sequential stream — text, thinking, or tool call */

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -929,6 +929,97 @@ html, body {
   color: var(--vscode-foreground);
 }
 
+/* Metrics tables */
+.gsd-dash-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+  margin-top: 4px;
+  table-layout: auto;
+  overflow-wrap: break-word;
+}
+
+.gsd-dash-table th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--vscode-descriptionForeground);
+  padding: 2px 6px 2px 0;
+  border-bottom: 1px solid var(--vscode-widget-border, rgba(128,128,128,0.2));
+}
+
+.gsd-dash-table td {
+  padding: 2px 6px 2px 0;
+  color: var(--vscode-foreground);
+}
+
+.gsd-dash-num {
+  text-align: right;
+  font-family: var(--vscode-editor-fontFamily);
+  font-variant-numeric: tabular-nums;
+}
+
+.gsd-dash-inline-breakdown {
+  font-size: 12px;
+}
+
+/* Projection */
+.gsd-dash-projection {
+  padding: 2px 0;
+}
+
+.gsd-dash-projection-line {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.gsd-dash-projection-line strong {
+  color: var(--vscode-foreground);
+}
+
+/* Activity log */
+.gsd-dash-activity {
+  font-size: 11px;
+  margin-top: 4px;
+}
+
+.gsd-dash-activity-scroll {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.gsd-dash-activity-row {
+  display: flex;
+  gap: 6px;
+  padding: 1px 0;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.gsd-dash-activity-type {
+  color: var(--vscode-descriptionForeground);
+  min-width: 90px;
+  text-transform: capitalize;
+}
+
+.gsd-dash-activity-id {
+  color: var(--vscode-foreground);
+  flex: 1;
+  font-family: var(--vscode-editor-fontFamily);
+}
+
+.gsd-dash-activity-cost {
+  color: var(--vscode-testing-iconPassed, #28a745);
+  font-family: var(--vscode-editor-fontFamily);
+  font-variant-numeric: tabular-nums;
+}
+
+.gsd-dash-activity-dur {
+  color: var(--vscode-descriptionForeground);
+  font-family: var(--vscode-editor-fontFamily);
+  min-width: 40px;
+  text-align: right;
+}
+
 /* ============================================================
    Entries
    ============================================================ */

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1647,6 +1647,157 @@ html, body {
   background: transparent;
 }
 
+/* ── Subagent panel ── */
+.gsd-subagent-panel {
+  padding: 6px 10px 8px;
+}
+
+.gsd-subagent-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0 8px;
+  font-size: 11px;
+  border-bottom: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.12));
+  margin-bottom: 6px;
+}
+
+.gsd-subagent-mode {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  color: var(--vscode-textLink-foreground, #3794ff);
+  background: rgba(55, 148, 255, 0.08);
+  padding: 2px 7px;
+  border-radius: 3px;
+}
+
+.gsd-subagent-counts {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.gsd-agent-stat {
+  font-size: 10.5px;
+  font-weight: 500;
+}
+.gsd-agent-stat.done { color: var(--vscode-terminal-ansiGreen, #89d185); }
+.gsd-agent-stat.running { color: var(--vscode-textLink-foreground, #3794ff); }
+.gsd-agent-stat.error { color: var(--vscode-errorForeground, #f48771); }
+.gsd-agent-sep { color: var(--vscode-descriptionForeground); opacity: 0.4; font-size: 10px; }
+
+.gsd-subagent-total {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Agent cards ── */
+.gsd-agent-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gsd-agent-card {
+  padding: 7px 9px;
+  border-radius: 4px;
+  border-left: 2px solid transparent;
+  background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.06));
+  transition: border-color 0.2s;
+}
+.gsd-agent-card.running { border-left-color: var(--vscode-textLink-foreground, #3794ff); }
+.gsd-agent-card.done { border-left-color: var(--vscode-terminal-ansiGreen, #89d185); }
+.gsd-agent-card.error { border-left-color: var(--vscode-errorForeground, #f48771); }
+
+.gsd-agent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 18px;
+}
+
+.gsd-agent-header-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.gsd-agent-icon {
+  font-size: 11px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.gsd-agent-icon.done { color: var(--vscode-terminal-ansiGreen, #89d185); }
+.gsd-agent-icon.error { color: var(--vscode-errorForeground, #f48771); }
+
+.gsd-agent-name {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gsd-agent-task {
+  font-size: 10.5px;
+  color: var(--vscode-descriptionForeground);
+  margin-top: 3px;
+  line-height: 1.45;
+  opacity: 0.8;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.gsd-agent-error {
+  font-size: 10.5px;
+  color: var(--vscode-errorForeground, #f48771);
+  margin-top: 3px;
+  line-height: 1.4;
+}
+
+/* Usage pills */
+.gsd-agent-usage {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.gsd-agent-pill {
+  font-size: 9.5px;
+  font-weight: 500;
+  color: var(--vscode-descriptionForeground);
+  background: rgba(128,128,128,0.08);
+  padding: 1px 5px;
+  border-radius: 3px;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.gsd-subagent-footer {
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.12));
+  display: flex;
+  justify-content: flex-end;
+}
+
+.gsd-subagent-footer .gsd-agent-pill {
+  opacity: 0.7;
+}
+
+/* ── Legacy subagent styles (fallback when no structured details) ── */
 .gsd-subagent-live {
   padding: 8px 10px;
 }


### PR DESCRIPTION
## M009: Dashboard Metrics & CLI Parity

### Changes
- **feat(M009/S01):** Metrics dashboard — phase/slice/model breakdowns, projections, activity log
- **fix(M009/S02):** Distinguish clean exit from crash in process status
- **fix:** Use os.tmpdir() for metrics parser tests to avoid Dropbox EBUSY locks
- **chore:** Bump version to 0.2.29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Version 0.2.29 Release Notes

* **New Features**
  * Metrics dashboard: project cost, token and time totals, projections, recent activity and breakdowns by phase, slice and model.
  * Enhanced subagent view with per-agent cards and aggregated usage.

* **Improvements**
  * More robust process lifecycle handling and deduplicated launch flow; clearer clean-exit vs crash signalling.
  * UI styling for metrics, projections, activity and subagent panels.

* **Tests**
  * Comprehensive test suite added for metrics parsing and aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->