### PR TITLE
fix: collapse stale background job echoes + intent-based auto-scroll

### DIFF
--- a/src/webview/__tests__/stale-echo.test.ts
+++ b/src/webview/__tests__/stale-echo.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { state, type AssistantTurn } from "../state";
+import { detectStaleEcho } from "../renderer";
+
+function makeTurn(overrides: Partial<AssistantTurn> = {}): AssistantTurn {
+  return {
+    id: `turn-${Math.random()}`,
+    segments: [{ type: "text", chunks: ["Short reply."] }],
+    toolCalls: new Map(),
+    isComplete: false,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("detectStaleEcho", () => {
+  beforeEach(() => {
+    state.entries = [];
+  });
+
+  it("returns false when there are no previous assistant entries", () => {
+    expect(detectStaleEcho(makeTurn())).toBe(false);
+  });
+
+  it("returns false when the turn has tool calls", () => {
+    const now = Date.now();
+    state.entries.push({ id: "prev", type: "assistant", timestamp: now - 5000, turn: makeTurn({ timestamp: now - 5000 }) });
+    const turn = makeTurn({ timestamp: now });
+    turn.toolCalls.set("tc1", { id: "tc1", name: "Read", args: {}, resultText: "", isError: false, isRunning: false, startTime: now });
+    expect(detectStaleEcho(turn)).toBe(false);
+  });
+
+  it("returns false when text is longer than 200 chars", () => {
+    const now = Date.now();
+    state.entries.push({ id: "prev", type: "assistant", timestamp: now - 5000, turn: makeTurn({ timestamp: now - 5000 }) });
+    expect(detectStaleEcho(makeTurn({ timestamp: now, segments: [{ type: "text", chunks: ["x".repeat(201)] }] }))).toBe(false);
+  });
+
+  it("returns false when a user entry exists between assistant turns", () => {
+    const now = Date.now();
+    state.entries.push({ id: "prev", type: "assistant", timestamp: now - 10000, turn: makeTurn({ timestamp: now - 10000 }) });
+    state.entries.push({ id: "user1", type: "user", text: "hello", timestamp: now - 5000 });
+    expect(detectStaleEcho(makeTurn({ timestamp: now }))).toBe(false);
+  });
+
+  it("returns false when previous turn is older than 30s", () => {
+    const now = Date.now();
+    state.entries.push({ id: "prev", type: "assistant", timestamp: now - 31000, turn: makeTurn({ timestamp: now - 31000 }) });
+    expect(detectStaleEcho(makeTurn({ timestamp: now }))).toBe(false);
+  });
+
+  it("returns false when turn has thinking segments", () => {
+    const now = Date.now();
+    state.entries.push({ id: "prev", type: "assistant", timestamp: now - 5000, turn: makeTurn({ timestamp: now - 5000 }) });
+    expect(detectStaleEcho(makeTurn({ timestamp: now, segments: [{ type: "thinking", chunks: ["hmm"] }, { type: "text", chunks: ["ok"] }] }))).toBe(false);
+  });
+
+  it("detects a stale echo: short text-only turn following assistant with no user in between", () => {
+    const now = Date.now();
+    state.entries.push({ id: "prev", type: "assistant", timestamp: now - 5000, turn: makeTurn({ timestamp: now - 5000 }) });
+    expect(detectStaleEcho(makeTurn({ timestamp: now, segments: [{ type: "text", chunks: ["Stale echo — already handled."] }] }))).toBe(true);
+  });
+
+  it("detects stale echo even with system entries in between", () => {
+    const now = Date.now();
+    state.entries.push({ id: "prev", type: "assistant", timestamp: now - 5000, turn: makeTurn({ timestamp: now - 5000 }) });
+    state.entries.push({ id: "sys1", type: "system", systemText: "info", timestamp: now - 2000 });
+    expect(detectStaleEcho(makeTurn({ timestamp: now }))).toBe(true);
+  });
+
+  it("detects multiple stale echoes in succession", () => {
+    const now = Date.now();
+    state.entries.push({ id: "t1", type: "assistant", timestamp: now - 10000, turn: makeTurn({ timestamp: now - 10000 }) });
+    state.entries.push({ id: "t2", type: "assistant", timestamp: now - 5000, turn: makeTurn({ timestamp: now - 5000 }) });
+    expect(detectStaleEcho(makeTurn({ timestamp: now }))).toBe(true);
+  });
+});

--- a/src/webview/helpers.ts
+++ b/src/webview/helpers.ts
@@ -489,7 +489,6 @@ export function initAutoScroll(container: HTMLElement): void {
     _scrollContainer.removeEventListener("scroll", _scrollHandler);
   }
 
-  _userScrolledUp = false;
   _lastScrollTop = container.scrollTop;
   _scrollContainer = container;
 

--- a/src/webview/helpers.ts
+++ b/src/webview/helpers.ts
@@ -489,7 +489,7 @@ export function initAutoScroll(container: HTMLElement): void {
     const { scrollTop, scrollHeight, clientHeight } = container;
     const distFromBottom = scrollHeight - scrollTop - clientHeight;
 
-    if (scrollTop < _lastScrollTop && distFromBottom > 50) {
+    if (scrollTop < _lastScrollTop) {
       // User scrolled up
       _userScrolledUp = true;
     } else if (distFromBottom < 30) {

--- a/src/webview/helpers.ts
+++ b/src/webview/helpers.ts
@@ -464,8 +464,57 @@ export function formatShortDate(iso: string): string {
   }
 }
 
+/**
+ * Auto-scroll to bottom of the message container.
+ *
+ * Uses intent-based tracking: we track whether the user has actively scrolled
+ * away from the bottom (userScrolledUp). Auto-scroll is suppressed when the
+ * user has scrolled up, and re-enabled when they scroll back near the bottom
+ * or click the scroll FAB.
+ *
+ * The `force` parameter bypasses intent tracking (used for user messages,
+ * new sessions, etc.).
+ */
+let _userScrolledUp = false;
+let _lastScrollTop = 0;
+let _scrollListenerAttached = false;
+
+export function initAutoScroll(container: HTMLElement): void {
+  if (_scrollListenerAttached) return;
+  _scrollListenerAttached = true;
+  _userScrolledUp = false;
+  _lastScrollTop = container.scrollTop;
+
+  container.addEventListener("scroll", () => {
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    const distFromBottom = scrollHeight - scrollTop - clientHeight;
+
+    if (scrollTop < _lastScrollTop && distFromBottom > 50) {
+      // User scrolled up
+      _userScrolledUp = true;
+    } else if (distFromBottom < 30) {
+      // User scrolled back to bottom (or auto-scroll brought us here)
+      _userScrolledUp = false;
+    }
+    _lastScrollTop = scrollTop;
+  }, { passive: true });
+}
+
+/** Reset scroll tracking (e.g. new session, clear messages) */
+export function resetAutoScroll(): void {
+  _userScrolledUp = false;
+  _lastScrollTop = 0;
+}
+
+/** Check if auto-scroll is currently suppressed by user intent */
+export function isAutoScrollSuppressed(): boolean {
+  return _userScrolledUp;
+}
+
 export function scrollToBottom(container: HTMLElement, force = false): void {
-  if (force || container.scrollHeight - container.scrollTop - container.clientHeight < 150) {
-    container.scrollTop = container.scrollHeight;
+  if (force) {
+    _userScrolledUp = false;
   }
+  if (_userScrolledUp) return;
+  container.scrollTop = container.scrollHeight;
 }

--- a/src/webview/helpers.ts
+++ b/src/webview/helpers.ts
@@ -477,27 +477,35 @@ export function formatShortDate(iso: string): string {
  */
 let _userScrolledUp = false;
 let _lastScrollTop = 0;
-let _scrollListenerAttached = false;
+let _scrollContainer: HTMLElement | null = null;
+let _scrollHandler: (() => void) | null = null;
 
 export function initAutoScroll(container: HTMLElement): void {
-  if (_scrollListenerAttached) return;
-  _scrollListenerAttached = true;
+  // If already attached to this container, skip
+  if (_scrollContainer === container) return;
+
+  // Detach from previous container if any
+  if (_scrollContainer && _scrollHandler) {
+    _scrollContainer.removeEventListener("scroll", _scrollHandler);
+  }
+
   _userScrolledUp = false;
   _lastScrollTop = container.scrollTop;
+  _scrollContainer = container;
 
-  container.addEventListener("scroll", () => {
+  _scrollHandler = () => {
     const { scrollTop, scrollHeight, clientHeight } = container;
     const distFromBottom = scrollHeight - scrollTop - clientHeight;
 
     if (scrollTop < _lastScrollTop) {
-      // User scrolled up
       _userScrolledUp = true;
     } else if (distFromBottom < 30) {
-      // User scrolled back to bottom (or auto-scroll brought us here)
       _userScrolledUp = false;
     }
     _lastScrollTop = scrollTop;
-  }, { passive: true });
+  };
+
+  container.addEventListener("scroll", _scrollHandler, { passive: true });
 }
 
 /** Reset scroll tracking (e.g. new session, clear messages) */

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -16,6 +16,9 @@ import {
 import {
   formatRelativeTime,
   scrollToBottom,
+  initAutoScroll,
+  resetAutoScroll,
+  isAutoScrollSuppressed,
 } from "./helpers";
 
 import * as slashMenu from "./slash-menu";
@@ -332,13 +335,17 @@ function isNearBottom(threshold = 100): boolean {
 }
 
 function updateScrollFab(): void {
-  const near = isNearBottom(100);
-  scrollFab.classList.toggle("visible", !near);
+  // Show FAB when auto-scroll is suppressed (user scrolled up) or not near bottom
+  const showFab = isAutoScrollSuppressed() || !isNearBottom(100);
+  scrollFab.classList.toggle("visible", showFab);
 }
 
+// Initialize intent-based auto-scroll tracking
+initAutoScroll(messagesContainer);
 messagesContainer.addEventListener("scroll", updateScrollFab, { passive: true });
 
 scrollFab.addEventListener("click", () => {
+  resetAutoScroll();
   messagesContainer.scrollTo({ top: messagesContainer.scrollHeight, behavior: "smooth" });
 });
 

--- a/src/webview/keyboard.ts
+++ b/src/webview/keyboard.ts
@@ -248,6 +248,21 @@ function setupClickHandlers(): void {
       return;
     }
 
+    // Stale echo expand/collapse
+    const staleBar = target.closest(".gsd-stale-echo-bar") as HTMLElement | null;
+    if (staleBar) {
+      const entry = staleBar.closest(".gsd-stale-echo") as HTMLElement | null;
+      if (entry) {
+        const full = entry.querySelector(".gsd-stale-echo-full") as HTMLElement | null;
+        if (full) {
+          const isHidden = full.hidden;
+          full.hidden = !isHidden;
+          staleBar.setAttribute("aria-expanded", String(isHidden));
+        }
+      }
+      return;
+    }
+
     if (target.closest("#restartBtn")) {
       vscode.postMessage({ type: "launch_gsd" });
       return;

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -290,6 +290,7 @@ export function finalizeCurrentTurn(): void {
   }
 
   const isStaleEcho = detectStaleEcho(turn);
+  turn.isStaleEcho = isStaleEcho;
 
   state.entries.push({
     id: turn.id,
@@ -302,17 +303,7 @@ export function finalizeCurrentTurn(): void {
     currentTurnElement.classList.remove("streaming");
     if (isStaleEcho) {
       currentTurnElement.classList.add("gsd-stale-echo");
-      const textContent = turn.segments
-        .filter(s => s.type === "text")
-        .map(s => s.chunks.join(""))
-        .join(" ")
-        .trim();
-      const preview = textContent.length > 80 ? textContent.slice(0, 77) + "…" : textContent;
-      currentTurnElement.innerHTML = `<div class="gsd-stale-echo-bar" role="button" tabindex="0" aria-label="Expand background notification echo" title="Background job notification — click to expand">
-        <span class="gsd-stale-echo-icon">↩</span>
-        <span class="gsd-stale-echo-text">${escapeHtml(preview)}</span>
-      </div>
-      <div class="gsd-stale-echo-full" hidden>${buildTurnHtml(turn)}</div>`;
+      currentTurnElement.innerHTML = buildStaleEchoHtml(turn);
     } else {
       currentTurnElement.innerHTML = buildTurnHtml(turn);
     }
@@ -344,7 +335,12 @@ function createEntryElement(entry: ChatEntry): HTMLElement {
   if (entry.type === "user") {
     el.innerHTML = buildUserHtml(entry);
   } else if (entry.type === "assistant" && entry.turn) {
-    el.innerHTML = buildTurnHtml(entry.turn);
+    if (entry.turn.isStaleEcho) {
+      el.classList.add("gsd-stale-echo");
+      el.innerHTML = buildStaleEchoHtml(entry.turn);
+    } else {
+      el.innerHTML = buildTurnHtml(entry.turn);
+    }
   } else if (entry.type === "system") {
     el.innerHTML = buildSystemHtml(entry);
   }
@@ -400,6 +396,21 @@ function buildUserHtml(entry: ChatEntry): string {
   html += `</div>`;
   html += buildTimestampHtml(entry.timestamp);
   return html;
+}
+
+function buildStaleEchoHtml(turn: AssistantTurn): string {
+  const textContent = turn.segments
+    .filter(s => s.type === "text")
+    .map(s => s.chunks.join(""))
+    .join(" ")
+    .trim();
+  const preview = textContent.length > 80 ? textContent.slice(0, 77) + "…" : textContent;
+  const panelId = `stale-echo-${turn.id}`;
+  return `<div class="gsd-stale-echo-bar" role="button" tabindex="0" aria-expanded="false" aria-controls="${escapeAttr(panelId)}" aria-label="Expand background notification echo" title="Background job notification — click to expand">
+    <span class="gsd-stale-echo-icon">↩</span>
+    <span class="gsd-stale-echo-text">${escapeHtml(preview)}</span>
+  </div>
+  <div class="gsd-stale-echo-full" id="${escapeAttr(panelId)}" hidden>${buildTurnHtml(turn)}</div>`;
 }
 
 function buildTurnHtml(turn: AssistantTurn): string {

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -23,6 +23,7 @@ import {
   buildSubagentOutputHtml,
   renderMarkdown,
   scrollToBottom,
+  resetAutoScroll,
 } from "./helpers";
 
 import {
@@ -87,6 +88,7 @@ function stopElapsedTimer(): void {
 export function clearMessages(): void {
   const els = messagesContainer.querySelectorAll(".gsd-entry");
   els.forEach((el) => el.remove());
+  resetAutoScroll();
 }
 
 export function renderNewEntry(entry: ChatEntry): void {
@@ -223,6 +225,53 @@ function tryStreamingCollapse(el: HTMLElement, segIdx: number): void {
   segmentElements.set(segIdx, groupEl);
 }
 
+/**
+ * Detect "stale echo" turns — short, text-only agent responses that occur
+ * in rapid succession without user interaction. These happen when async_bash
+ * job results are delivered after the agent has already consumed them,
+ * triggering redundant model turns that just say "already handled."
+ *
+ * Conditions (ALL must be true):
+ * 1. No tool calls — the model didn't do any work
+ * 2. Text-only, short — total text < 200 chars
+ * 3. No user entry between this turn and the previous assistant turn
+ * 4. Previous assistant turn exists
+ * 5. Completed within 30s of the previous assistant turn
+ *
+ * @internal — exported for testing
+ */
+export function detectStaleEcho(turn: AssistantTurn): boolean {
+  if (turn.toolCalls.size > 0) return false;
+
+  const textSegments = turn.segments.filter(s => s.type === "text");
+  if (textSegments.length === 0) return false;
+  if (turn.segments.some(s => s.type === "thinking")) return false;
+
+  const totalText = textSegments
+    .map(s => s.chunks.join(""))
+    .join("")
+    .trim();
+  if (totalText.length > 200) return false;
+
+  let lastAssistantIdx = -1;
+  for (let i = state.entries.length - 1; i >= 0; i--) {
+    if (state.entries[i].type === "assistant") {
+      lastAssistantIdx = i;
+      break;
+    }
+  }
+  if (lastAssistantIdx === -1) return false;
+
+  for (let i = lastAssistantIdx + 1; i < state.entries.length; i++) {
+    if (state.entries[i].type === "user") return false;
+  }
+
+  const prevTimestamp = state.entries[lastAssistantIdx].timestamp;
+  if (turn.timestamp - prevTimestamp > 30000) return false;
+
+  return true;
+}
+
 export function finalizeCurrentTurn(): void {
   if (!state.currentTurn) return;
 
@@ -240,6 +289,8 @@ export function finalizeCurrentTurn(): void {
     tc.isRunning = false;
   }
 
+  const isStaleEcho = detectStaleEcho(turn);
+
   state.entries.push({
     id: turn.id,
     type: "assistant",
@@ -249,7 +300,22 @@ export function finalizeCurrentTurn(): void {
 
   if (currentTurnElement) {
     currentTurnElement.classList.remove("streaming");
-    currentTurnElement.innerHTML = buildTurnHtml(turn);
+    if (isStaleEcho) {
+      currentTurnElement.classList.add("gsd-stale-echo");
+      const textContent = turn.segments
+        .filter(s => s.type === "text")
+        .map(s => s.chunks.join(""))
+        .join(" ")
+        .trim();
+      const preview = textContent.length > 80 ? textContent.slice(0, 77) + "…" : textContent;
+      currentTurnElement.innerHTML = `<div class="gsd-stale-echo-bar" role="button" tabindex="0" aria-label="Expand background notification echo" title="Background job notification — click to expand">
+        <span class="gsd-stale-echo-icon">↩</span>
+        <span class="gsd-stale-echo-text">${escapeHtml(preview)}</span>
+      </div>
+      <div class="gsd-stale-echo-full" hidden>${buildTurnHtml(turn)}</div>`;
+    } else {
+      currentTurnElement.innerHTML = buildTurnHtml(turn);
+    }
   }
 
   state.currentTurn = null;

--- a/src/webview/state.ts
+++ b/src/webview/state.ts
@@ -45,6 +45,8 @@ export interface AssistantTurn {
   toolCalls: Map<string, ToolCallState>;
   isComplete: boolean;
   timestamp: number;
+  /** True when this turn was detected as a stale background job echo */
+  isStaleEcho?: boolean;
 }
 
 export interface ChatEntry {

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -423,7 +423,6 @@ html, body {
   overflow-y: auto;
   overflow-x: hidden;
   padding: 12px 16px;
-  scroll-behavior: smooth;
 }
 
 .gsd-messages::-webkit-scrollbar {
@@ -3737,4 +3736,46 @@ html, body {
   .gsd-user-bubble { max-width: 95%; }
   .gsd-footer { padding: 2px 8px; font-size: 9px; }
   .gsd-welcome-ascii { font-size: 8px; }
+}
+
+/* ============================================================
+   Stale Echo — collapsed background job notification echoes
+   ============================================================ */
+
+.gsd-stale-echo {
+  margin: 2px 0;
+}
+
+.gsd-stale-echo-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  background: var(--vscode-editor-inactiveSelectionBackground, rgba(128, 128, 128, 0.1));
+  cursor: pointer;
+  opacity: 0.6;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground, #888);
+  transition: opacity 0.15s;
+  user-select: none;
+}
+
+.gsd-stale-echo-bar:hover {
+  opacity: 0.9;
+}
+
+.gsd-stale-echo-icon {
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.gsd-stale-echo-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gsd-stale-echo-full {
+  margin-top: 4px;
 }


### PR DESCRIPTION
Two UX fixes. See commit message for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stale response detection: repeated AI replies shown as collapsed preview bars that can be expanded to reveal full content
  * Smart auto-scroll: respects user scroll intent and suppresses automatic scrolling when users scroll up
  * Scroll-to-bottom control: button appears while auto-scroll is suppressed and resets scrolling when used
  * Click-to-expand stale previews for full content

* **Style**
  * Removed smooth page scrolling for more immediate behaviour

* **Tests**
  * Added tests covering stale response detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->