### PR TITLE
feat: add /gsd do and /gsd note slash commands (gsd-pi 1.25.0 parity)

### DIFF
--- a/src/webview/slash-menu.ts
+++ b/src/webview/slash-menu.ts
@@ -130,6 +130,8 @@ function buildItems(): SlashMenuItem[] {
     { name: "gsd doctor", desc: "Diagnose and fix issues" },
     { name: "gsd migrate", desc: "Migrate project artifacts" },
     { name: "gsd remote", desc: "Remote question channels (Slack, Discord)" },
+    { name: "gsd do", desc: "Freeform text — routes natural language to the right command" },
+    { name: "gsd note", desc: "Quick idea capture (append, list, promote)" },
   ];
 
   for (const sub of gsdSubcommands) {


### PR DESCRIPTION
Registers two new gsd-pi 1.25.0 commands in the VS Code extension slash menu:

- **/gsd do** — Freeform text router that dispatches natural language to the right GSD command
- **/gsd note** — Quick idea capture with append, list, and promote-to-todo subcommands

Both require user-typed arguments, so sendOnSelect is not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "gsd do" command: Users can now enter freeform natural language requests which are automatically routed to the most appropriate command for execution
  * Added "gsd note" command: A new quick note capture feature with flexible options to append to existing notes, list all notes, or promote important ones

<!-- end of auto-generated comment: release notes by coderabbit.ai -->