### PR TITLE
feat: improve compaction visibility and block input during compaction

### DIFF
--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -408,6 +408,10 @@ promptInput.addEventListener("input", () => {
 function sendMessage(): void {
   slashMenu.hide();
   modelPicker.hide();
+
+  // Block sending during compaction
+  if (state.isCompacting) return;
+
   const text = promptInput.value.trim();
   if (!text && state.images.length === 0 && state.files.length === 0) return;
 

--- a/src/webview/keyboard.ts
+++ b/src/webview/keyboard.ts
@@ -80,7 +80,10 @@ export function init(deps: KeyboardDeps): void {
 function setupKeyboardHandlers(): void {
   promptInput.addEventListener("keydown", (e: KeyboardEvent) => {
     // Block prompt input while visualizer overlay is open
-    if (visualizer.isVisible()) return;
+    if (visualizer.isVisible()) {
+      e.preventDefault();
+      return;
+    }
 
     if (sessionHistory.isVisible()) {
       if (sessionHistory.handleKeyDown(e)) return;
@@ -111,12 +114,12 @@ function setupKeyboardHandlers(): void {
     if (state.useCtrlEnterToSend) {
       if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
         e.preventDefault();
-        sendMessage();
+        if (!state.isCompacting) sendMessage();
       }
     } else {
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
-        sendMessage();
+        if (!state.isCompacting) sendMessage();
       }
     }
     if (e.key === "Escape" && state.isStreaming) {
@@ -283,6 +286,7 @@ function setupClickHandlers(): void {
 
 function setupButtonHandlers(): void {
   sendBtn.addEventListener("click", () => {
+    if (state.isCompacting) return;
     if (state.isStreaming) {
       vscode.postMessage({ type: "interrupt" });
     } else {

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -407,12 +407,14 @@ function handleMessage(event: MessageEvent): void {
     case "auto_compaction_start": {
       state.isCompacting = true;
       updateOverlayIndicators();
+      updateInputUI();
       break;
     }
 
     case "auto_compaction_end": {
       state.isCompacting = false;
       updateOverlayIndicators();
+      updateInputUI();
       break;
     }
 
@@ -488,12 +490,14 @@ function handleMessage(event: MessageEvent): void {
 
     case "session_shutdown": {
       state.isStreaming = false;
+      state.isCompacting = false;
       state.processStatus = "stopped";
       // Clean up any in-progress turn
       if (state.currentTurn) {
         renderer.finalizeCurrentTurn();
       }
       addSystemEntry("Session ended", "info");
+      updateInputUI();
       updateOverlayIndicators();
       break;
     }
@@ -837,7 +841,6 @@ function extractMessageText(content: unknown): string {
   return "";
 }
 
-/**
 // ============================================================
 // Theme
 // ============================================================

--- a/src/webview/slash-menu.ts
+++ b/src/webview/slash-menu.ts
@@ -253,6 +253,8 @@ function selectCommand(idx: number): void {
   }
 
   if (item.sendOnSelect) {
+    // Block sending during compaction
+    if (state.isCompacting) { hide(); return; }
     // Execute immediately — set the text and trigger send
     promptInput.value = item.insertText.trimEnd();
     onAutoResize();

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -372,8 +372,10 @@ html, body {
 }
 
 .gsd-overlay-indicator.compacting {
-  background: rgba(100, 140, 220, 0.06);
+  background: rgba(100, 140, 220, 0.12);
   color: var(--vscode-textLink-foreground, #3794ff);
+  font-size: 12px;
+  padding: 8px 14px;
 }
 
 .gsd-overlay-indicator.retrying {
@@ -2699,6 +2701,11 @@ html, body {
   color: var(--vscode-input-placeholderForeground);
 }
 
+.gsd-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* File chips — input area (pre-send) */
 .gsd-file-chips {
   display: none;
@@ -2822,6 +2829,12 @@ html, body {
 
 .gsd-send-btn.gsd-stop-btn:hover {
   background: rgba(220, 60, 60, 0.3);
+}
+
+.gsd-send-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .gsd-input-hint {

--- a/src/webview/ui-updates.ts
+++ b/src/webview/ui-updates.ts
@@ -207,12 +207,24 @@ export function updateInputUI(): void {
     logo.classList.toggle("working", state.isStreaming);
   }
 
-  if (state.isStreaming) {
+  if (state.isCompacting) {
+    sendIcon.textContent = "⟳";
+    sendBtn.classList.add("gsd-stop-btn");
+    sendBtn.title = "Compacting context…";
+    (sendBtn as HTMLButtonElement).disabled = true;
+    promptInput.placeholder = "Compacting context — please wait…";
+    promptInput.disabled = true;
+    inputHint.textContent = "Context window is being compacted";
+  } else if (state.isStreaming) {
+    (sendBtn as HTMLButtonElement).disabled = false;
+    promptInput.disabled = false;
     sendIcon.textContent = "■";
     sendBtn.classList.add("gsd-stop-btn");
     sendBtn.title = "Stop (Esc)";
     promptInput.placeholder = "Interrupt or steer GSD...";
   } else {
+    (sendBtn as HTMLButtonElement).disabled = false;
+    promptInput.disabled = false;
     sendIcon.textContent = "↑";
     sendBtn.classList.remove("gsd-stop-btn");
     sendBtn.title = "Send";
@@ -220,10 +232,12 @@ export function updateInputUI(): void {
   }
 
   const sendKey = state.useCtrlEnterToSend ? "Ctrl+Enter" : "Enter";
-  if (state.isStreaming) {
-    inputHint.textContent = `${sendKey} to steer • Esc to stop`;
-  } else {
-    inputHint.textContent = `${sendKey} to send • !cmd for bash • / for commands`;
+  if (!state.isCompacting) {
+    if (state.isStreaming) {
+      inputHint.textContent = `${sendKey} to steer • Esc to stop`;
+    } else {
+      inputHint.textContent = `${sendKey} to send • !cmd for bash • / for commands`;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Improves the UX during context compaction by making the state clearly visible and preventing message sending that would result in 'Message sent but not processed' warnings.

## Changes

- **Input lockout**: Disable textarea and send button while context is compacting
- **Visual feedback**: Show ⟳ icon, 'Compacting context — please wait…' placeholder, and 'Context window is being compacted' hint
- **Keyboard blocking**: Block Enter/Ctrl+Enter and send button click during compaction
- **Overlay indicator**: Increased visibility with larger text, more padding, and higher opacity background
- **CSS**: Added :disabled styles for input and send button
- **Tests**: Updated to reflect compacting-takes-priority-over-streaming behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevents message sending during background compaction across keyboard shortcuts, send button, and menu selections; UI is updated to reflect the disabled state.
  * Ensures input UI resets when a session shutdown completes.

* **Style**
  * Improved compacting indicator styling (higher contrast, padding, font-size).
  * Added disabled-state styling for input and send controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->