### PR TITLE
fix: show structured dashboard for /gsd status instead of wall of text

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.2.62-blue" alt="Version" />
-  <img src="https://img.shields.io/badge/gsd--pi-v2.12--v2.35-blue" alt="gsd-pi compatibility" />
+  <img src="https://img.shields.io/badge/version-0.2.69-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/gsd--pi-v2.12--v2.40-blue" alt="gsd-pi compatibility" />
   <img src="https://img.shields.io/badge/VS%20Code-1.94%2B-blue" alt="VS Code" />
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License" />
   <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey" alt="Platform" />
@@ -30,7 +30,7 @@
 
 <img width="1670" height="1005" alt="RokketGSD" src="https://github.com/user-attachments/assets/e68aea08-cb2c-415f-ad2e-dbad08d39dbc"/>
 
-Rokket GSD turns the `gsd-pi` CLI into a native VS Code experience. Streaming responses, 40+ tool visualizations, parallel worker dashboards, model controls, four built-in themes, and deep workflow integration. Everything runs inside your editor.
+Rokket GSD turns the `gsd-pi` CLI into a native VS Code experience. Streaming responses, 40+ tool visualizations, async subagent monitoring, parallel worker dashboards, model controls, four built-in themes, and deep workflow integration. Everything runs inside your editor.
 
 The extension spawns GSD as a child process over JSON-RPC (`gsd --mode rpc`), giving the agent full access to your workspace, tools, and configured providers while you get a proper UI on top.
 
@@ -48,7 +48,7 @@ One-click install from GitHub Releases
 📂 **Session History**<br>
 Search, rename, resume right where you left off
 
-⌨️ **32 Slash Commands**<br>
+⌨️ **35 Slash Commands**<br>
 Full GSD workflow from a single `/` keystroke
 
 🧠 **Model Picker**<br>
@@ -80,6 +80,9 @@ Warning toast when workers cross 80% of ceiling
 
 🛡️ **Process Resilience**<br>
 Built for multi-hour sessions with crash recovery
+
+🧪 **850 Tests, 60%+ Coverage**<br>
+CI coverage gate enforced on every push
 
 </td>
 </tr>
@@ -156,10 +159,10 @@ Then reload VS Code (`Ctrl+Shift+P` > "Developer: Reload Window").
 
 ### ⌨️ Slash Commands
 
-Type `/` to open the command palette with 32 commands:
+Type `/` to open the command palette with 35 commands:
 
 <details>
-<summary><strong>GSD Workflow</strong> (23 commands)</summary>
+<summary><strong>GSD Workflow</strong> (25 commands)</summary>
 
 | Command | What it does |
 |---------|-------------|
@@ -187,11 +190,12 @@ Type `/` to open the command palette with 32 commands:
 | `/gsd note` | Quick idea capture (append, list, promote) |
 | `/gsd update` | Update GSD artifacts and status |
 | `/gsd export` | Export milestone report (supports `--html --all`) |
+| `/gsd rate` | Token usage rates and profile defaults |
 
 </details>
 
 <details>
-<summary><strong>Built-in Actions</strong> (9 commands)</summary>
+<summary><strong>Built-in Actions</strong> (10 commands)</summary>
 
 | Command | What it does |
 |---------|-------------|
@@ -204,6 +208,7 @@ Type `/` to open the command palette with 32 commands:
 | `/copy` | Copy last assistant message |
 | `/resume` | Resume last session |
 | `/auto-compact` | Toggle auto-compaction on/off |
+| `/auto-retry` | Toggle auto-retry on transient errors |
 
 </details>
 
@@ -226,6 +231,7 @@ Type `/` to open the command palette with 32 commands:
 - **Message timestamps** with relative times that update live and absolute times on hover
 - **Thinking blocks** collapsed by default with line count indicator, expanded during streaming
 - **Steer while streaming** to redirect the agent mid-task without stopping it
+- **Steer persistence** — messages sent during auto-mode are saved to `OVERRIDES.md` and apply to all future tasks, not just the current turn
 - **Drag-to-resize input area** for longer messages
 - **`!command` shortcut** to run bash commands directly without the agent
 
@@ -238,6 +244,7 @@ Type `/` to open the command palette with 32 commands:
 - **Parallel tool indicator** with ⚡ badge and pulse animation when tools run concurrently
 - **Tool call grouping** collapses consecutive read-only tools (file reads, searches, browser reads) into expandable summary rows
 - **Subagent results** rendered as full markdown with usage pills showing token and cost breakdowns
+- **Async subagent cards** — live-updating cards for background agents showing turns, usage, cost, and model. Cards transition from running (spinner) to done (green ✓) or error (red) as agents complete.
 - **Clickable file paths** that open directly in VS Code
 - **Shimmer animation** on running tools so you always know what's active
 - **Duration tracking** on every completed tool call
@@ -250,6 +257,8 @@ Type `/` to open the command palette with 32 commands:
 - **Pending captures badge** (📌) in the progress widget for `/gsd capture` thoughts awaiting triage
 - **Workflow state badge** in the header showing active milestone, slice, task, and current phase
 - **Auto-mode indicator** with ⚡ Auto, ▸ Next, ⏸ Paused states
+- **Health widget** — ambient system health bar in the footer showing system status, budget, provider issues, and environment errors
+- **Model health indicator** — green/amber/red dot next to the model name reflecting current system health
 
 ### 📊 Parallel Worker Dashboard
 
@@ -262,9 +271,10 @@ Type `/` to open the command palette with 32 commands:
 
 ### 📈 Workflow Visualizer
 
-- **Full-page overlay** via `/gsd visualize` with two tabs
+- **Full-page overlay** via `/gsd visualize` with three tabs
 - **Progress tab** with milestone header, progress bars, slice/task breakdown, milestone registry, blockers, and next action
 - **Metrics tab** with cost breakdown, tool call counts, model usage, token breakdown, and context usage
+- **Health tab** with system health status, budget info, environment warnings, and active model
 - **Auto-refresh** every 5 seconds during active auto-mode
 - **Dashboard panel** with milestone registry, slice/task progress, cost projections, and activity log
 
@@ -273,7 +283,7 @@ Type `/` to open the command palette with 32 commands:
 - **Inline UI dialogs** for confirm, select, input, and editor prompts rendered directly in the chat flow (no modal popups)
 - **Multi-select support** with checkbox-style selection and confirm button
 - **Auto-compaction indicator** overlay banner when context is being compacted
-- **Auto-retry indicator** with countdown timer when the provider rate-limits
+- **Auto-retry indicator** with countdown timer and abort button when the provider rate-limits
 - **Provider fallback alerts** via toast when GSD auto-switches models due to rate limits, and again when the original provider recovers
 - **Crash recovery** with restart button and full state cleanup
 
@@ -365,11 +375,11 @@ Built to handle real-world agent sessions that run for hours:
                                           └──────────────────────┘
 ```
 
-- **Webview** - vanilla DOM (no framework), ~13K lines of TypeScript, esbuild-bundled IIFE. Sequential segment-based renderer with `requestAnimationFrame` batching for smooth streaming.
-- **Extension Host** - manages the GSD child process, routes messages, handles file operations, monitors health, polls parallel worker status.
+- **Webview** - vanilla DOM (no framework), ~9K lines of TypeScript, esbuild-bundled IIFE. Sequential segment-based renderer with `requestAnimationFrame` batching for smooth streaming.
+- **Extension Host** - ~12K lines of TypeScript managing the GSD child process, routes messages, handles file operations, monitors health, polls parallel worker status.
 - **GSD Process** - the full `gsd-pi` agent running via JSON-RPC over stdin/stdout. Each session gets its own process.
 
-The extension ships as a ~147KB `.vsix` with no runtime dependencies beyond VS Code and the `gsd` CLI.
+The extension ships as a ~151KB `.vsix` with no runtime dependencies beyond VS Code and the `gsd` CLI.
 
 ---
 
@@ -390,7 +400,7 @@ npm run watch    # Rebuilds on file changes
 |--------|-------------|
 | `npm run build` | Production build (extension + webview) |
 | `npm run watch` | Watch mode with auto-rebuild |
-| `npm test` | Run unit tests (Vitest, 299 tests across 16 files) |
+| `npm test` | Run unit tests (Vitest, 850 tests across 44 files) |
 | `npm run lint` | Run ESLint |
 | `npm run package` | Package as `.vsix` |
 
@@ -422,7 +432,7 @@ src/
     dashboard.ts            # GSD dashboard overlay
     model-picker.ts         # Model selection overlay
     thinking-picker.ts      # Thinking level dropdown
-    slash-menu.ts           # Slash command palette (32 commands)
+    slash-menu.ts           # Slash command palette (35 commands)
     ui-dialogs.ts           # Inline confirm/select/input dialogs
     tool-grouping.ts        # Read-only tool collapse logic
     session-history.ts      # Session browser panel
@@ -444,7 +454,7 @@ resources/
 
 - **Requires `gsd-pi`** - this is a UI wrapper, not a standalone agent. The `gsd` CLI must be installed and configured separately.
 - **Not on the VS Code Marketplace** - install via `.vsix` from [GitHub Releases](https://github.com/Kile-Thomson/Rokket-GSD/releases) or the install scripts above.
-- **GSD custom UI commands** (like the TUI dashboard) require widget support that VS Code's webview doesn't provide. These commands work but produce text-only output.
+- **Some GSD custom UI commands** still rely on TUI widgets that VS Code webviews cannot render directly. `/gsd status` (and `/gsd auto` when requesting status) is supported via Rokket GSD's structured dashboard renderer; other widget-dependent commands produce text-only output.
 
 ---
 

--- a/src/extension/file-ops.ts
+++ b/src/extension/file-ops.ts
@@ -162,7 +162,7 @@ export async function handleExportHtml(
     /* Export overrides */
     body { background: #1e1e1e; color: #cccccc; max-width: 880px; margin: 0 auto; padding: 32px 24px; }
     .gsd-welcome, .gsd-scroll-fab, .gsd-slash-menu, .gsd-model-picker, .gsd-thinking-picker,
-    .gsd-session-history, .gsd-copy-response-btn, .gsd-fork-btn, .gsd-retry-btn,
+    .gsd-session-history, .gsd-copy-response-btn, .gsd-retry-btn,
     .gsd-turn-actions, .gsd-input-area, .gsd-header, .gsd-footer,
     .gsd-overlay-indicators, .gsd-context-bar-container { display: none !important; }
     .gsd-messages { padding: 0; }

--- a/src/extension/message-dispatch.test.ts
+++ b/src/extension/message-dispatch.test.ts
@@ -83,7 +83,6 @@ function createMockClient(overrides: Record<string, unknown> = {}) {
     abort: vi.fn().mockResolvedValue(undefined),
     restart: vi.fn().mockResolvedValue(true),
     forceKill: vi.fn(),
-    fork: vi.fn().mockResolvedValue(undefined),
     getState: vi.fn().mockResolvedValue({
       model: { id: "test-model" },
       thinkingLevel: "off",
@@ -95,7 +94,6 @@ function createMockClient(overrides: Record<string, unknown> = {}) {
       autoCompactionEnabled: false,
     }),
     getMessages: vi.fn().mockResolvedValue({ messages: [{ role: "user", text: "hello" }] }),
-    getForkMessages: vi.fn().mockResolvedValue({ messages: [{ entryId: "abc123", text: "hello" }] }),
     getCommands: vi.fn().mockResolvedValue({ commands: [{ name: "/test" }] }),
     getAvailableModels: vi.fn().mockResolvedValue({ models: [] }),
     getSessionStats: vi.fn().mockResolvedValue({ cost: 0.01, tokens: { input: 100, output: 200, cacheRead: 0, cacheWrite: 0, total: 300 } }),
@@ -208,92 +206,6 @@ describe("message-dispatch: handleWebviewMessage", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
-  });
-
-  // ── fork_conversation ───────────────────────────────────────────────
-
-  describe("fork_conversation", () => {
-    it("calls client.fork, getState, getMessages and posts session_switched", async () => {
-      const client = createMockClient();
-      const session = createMockSession({ client: client as any });
-      const { ctx, webview } = createMockDispatchContext(session);
-
-      await handleWebviewMessage(ctx, webview, SESSION_ID, {
-        type: "fork_conversation",
-        entryId: "entry-42",
-      } as WebviewToExtensionMessage);
-
-      expect(client.fork).toHaveBeenCalledWith("entry-42");
-      expect(client.getState).toHaveBeenCalled();
-      expect(client.getMessages).toHaveBeenCalled();
-      expect(ctx.postToWebview).toHaveBeenCalledWith(
-        webview,
-        expect.objectContaining({ type: "session_switched" }),
-      );
-    });
-
-    it("resets accumulatedCost and emits cost:0 on fork", async () => {
-      const client = createMockClient();
-      const session = createMockSession({ client: client as any, accumulatedCost: 5.00 });
-      const { ctx, webview } = createMockDispatchContext(session);
-
-      await handleWebviewMessage(ctx, webview, SESSION_ID, {
-        type: "fork_conversation",
-        entryId: "entry-1",
-      } as WebviewToExtensionMessage);
-
-      expect(session.accumulatedCost).toBe(0);
-      expect(ctx.emitStatus).toHaveBeenCalledWith({ cost: 0 });
-    });
-
-    it("includes forkEntries from getForkMessages in session_switched payload", async () => {
-      const forkEntries = [{ entryId: "srv-1", text: "first" }, { entryId: "srv-2", text: "second" }];
-      const client = createMockClient({
-        getForkMessages: vi.fn().mockResolvedValue({ messages: forkEntries }),
-      });
-      const session = createMockSession({ client: client as any });
-      const { ctx, webview } = createMockDispatchContext(session);
-
-      await handleWebviewMessage(ctx, webview, SESSION_ID, {
-        type: "fork_conversation",
-        entryId: "entry-1",
-      } as WebviewToExtensionMessage);
-
-      expect(client.getForkMessages).toHaveBeenCalled();
-      expect(ctx.postToWebview).toHaveBeenCalledWith(
-        webview,
-        expect.objectContaining({ type: "session_switched", forkEntries }),
-      );
-    });
-
-    it("posts error when fork throws", async () => {
-      const client = createMockClient({ fork: vi.fn().mockRejectedValue(new Error("fork failed")) });
-      const session = createMockSession({ client: client as any });
-      const { ctx, webview } = createMockDispatchContext(session);
-
-      await handleWebviewMessage(ctx, webview, SESSION_ID, {
-        type: "fork_conversation",
-        entryId: "entry-bad",
-      } as WebviewToExtensionMessage);
-
-      expect(ctx.postToWebview).toHaveBeenCalledWith(
-        webview,
-        expect.objectContaining({ type: "error", message: expect.stringContaining("fork failed") }),
-      );
-    });
-
-    it("does nothing when client is not running", async () => {
-      const client = createMockClient({ isRunning: false });
-      const session = createMockSession({ client: client as any });
-      const { ctx, webview } = createMockDispatchContext(session);
-
-      await handleWebviewMessage(ctx, webview, SESSION_ID, {
-        type: "fork_conversation",
-        entryId: "entry-1",
-      } as WebviewToExtensionMessage);
-
-      expect(client.fork).not.toHaveBeenCalled();
-    });
   });
 
   // ── new_conversation ────────────────────────────────────────────────
@@ -413,26 +325,6 @@ describe("message-dispatch: handleWebviewMessage", () => {
       expect(ctx.postToWebview).toHaveBeenCalledWith(
         webview,
         expect.objectContaining({ type: "session_switched" }),
-      );
-    });
-
-    it("includes forkEntries in session_switched payload", async () => {
-      const forkEntries = [{ entryId: "x1", text: "msg1" }];
-      const client = createMockClient({
-        getForkMessages: vi.fn().mockResolvedValue({ messages: forkEntries }),
-      });
-      const session = createMockSession({ client: client as any });
-      const { ctx, webview } = createMockDispatchContext(session);
-
-      await handleWebviewMessage(ctx, webview, SESSION_ID, {
-        type: "switch_session",
-        path: "/sessions/other.jsonl",
-      } as WebviewToExtensionMessage);
-
-      expect(client.getForkMessages).toHaveBeenCalled();
-      expect(ctx.postToWebview).toHaveBeenCalledWith(
-        webview,
-        expect.objectContaining({ type: "session_switched", forkEntries }),
       );
     });
 
@@ -1139,6 +1031,274 @@ describe("message-dispatch: handleWebviewMessage", () => {
       } as WebviewToExtensionMessage);
 
       expect(client.setFollowUpMode).toHaveBeenCalledWith("all");
+    });
+  });
+
+  describe("/gsd status triggers dashboard", () => {
+    it("sends dashboard_data when /gsd status is sent", async () => {
+      const client = createMockClient();
+      const session = createMockSession({ client: client as any });
+      const { ctx, webview } = createMockDispatchContext(session);
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "prompt",
+        message: "/gsd status",
+      } as WebviewToExtensionMessage);
+
+      expect(client.prompt).toHaveBeenCalledWith("/gsd status", undefined);
+      // Dashboard data should also be sent
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect(dashboardCalls.length).toBe(1);
+    });
+
+    it("sends dashboard_data when /gsd auto mentions status", async () => {
+      const client = createMockClient();
+      const session = createMockSession({ client: client as any });
+      const { ctx, webview } = createMockDispatchContext(session);
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "prompt",
+        message: "/gsd auto View status: Review what was built",
+      } as WebviewToExtensionMessage);
+
+      expect(client.prompt).toHaveBeenCalled();
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect(dashboardCalls.length).toBe(1);
+    });
+
+    it("does NOT send dashboard_data for normal prompts", async () => {
+      const client = createMockClient();
+      const session = createMockSession({ client: client as any });
+      const { ctx, webview } = createMockDispatchContext(session);
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "prompt",
+        message: "Hello, how are you?",
+      } as WebviewToExtensionMessage);
+
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect(dashboardCalls.length).toBe(0);
+    });
+
+    it("does NOT send dashboard_data for /gsd auto without status keyword", async () => {
+      const client = createMockClient();
+      const session = createMockSession({ client: client as any });
+      const { ctx, webview } = createMockDispatchContext(session);
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "prompt",
+        message: "/gsd auto Continue with the next task",
+      } as WebviewToExtensionMessage);
+
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect(dashboardCalls.length).toBe(0);
+    });
+  });
+
+  describe("get_dashboard", () => {
+    it("builds and sends dashboard data", async () => {
+      const { buildDashboardData } = await import("./dashboard-parser");
+      (buildDashboardData as ReturnType<typeof vi.fn>).mockResolvedValue({
+        hasProject: true,
+        hasMilestone: true,
+        slices: [{ id: "S01", done: false }],
+      });
+
+      const client = createMockClient();
+      const session = createMockSession({ client: client as any });
+      const { ctx, webview } = createMockDispatchContext(session);
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "get_dashboard",
+      } as WebviewToExtensionMessage);
+
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect(dashboardCalls.length).toBe(1);
+      expect((dashboardCalls[0][1] as Record<string, unknown>).data).toBeTruthy();
+    });
+
+    it("merges session stats into dashboard data", async () => {
+      const { buildDashboardData } = await import("./dashboard-parser");
+      (buildDashboardData as ReturnType<typeof vi.fn>).mockResolvedValue({
+        hasProject: true,
+        hasMilestone: true,
+        slices: [],
+      });
+
+      const client = createMockClient({
+        getSessionStats: vi.fn().mockResolvedValue({
+          cost: 0.42,
+          tokens: { input: 500, output: 300, cacheRead: 10, cacheWrite: 5, total: 815 },
+          toolCalls: 12,
+          userMessages: 3,
+        }),
+      });
+      const session = createMockSession({ client: client as any });
+      const { ctx, webview } = createMockDispatchContext(session);
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "get_dashboard",
+      } as WebviewToExtensionMessage);
+
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect(dashboardCalls.length).toBe(1);
+      const data = (dashboardCalls[0][1] as any).data;
+      expect(data.stats).toBeDefined();
+      expect(data.stats.cost).toBe(0.42);
+      expect(data.stats.toolCalls).toBe(12);
+    });
+
+    it("sends null data when buildDashboardData throws", async () => {
+      const { buildDashboardData } = await import("./dashboard-parser");
+      (buildDashboardData as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("parse error"));
+
+      const { ctx, webview } = createMockDispatchContext();
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "get_dashboard",
+      } as WebviewToExtensionMessage);
+
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect(dashboardCalls.length).toBe(1);
+      expect((dashboardCalls[0][1] as any).data).toBeNull();
+    });
+
+    it("sends dashboard data even when session stats fail", async () => {
+      const { buildDashboardData } = await import("./dashboard-parser");
+      (buildDashboardData as ReturnType<typeof vi.fn>).mockResolvedValue({
+        hasProject: true,
+        hasMilestone: true,
+        slices: [],
+      });
+
+      const client = createMockClient({
+        getSessionStats: vi.fn().mockRejectedValue(new Error("stats unavailable")),
+      });
+      const session = createMockSession({ client: client as any });
+      const { ctx, webview } = createMockDispatchContext(session);
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "get_dashboard",
+      } as WebviewToExtensionMessage);
+
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect(dashboardCalls.length).toBe(1);
+      expect((dashboardCalls[0][1] as any).data).toBeTruthy();
+      // Stats should be absent since getSessionStats threw
+      expect((dashboardCalls[0][1] as any).data.stats).toBeUndefined();
+    });
+
+    it("merges metrics when ledger is available", async () => {
+      const { buildDashboardData } = await import("./dashboard-parser");
+      const { loadMetricsLedger, buildMetricsData } = await import("./metrics-parser");
+      (buildDashboardData as ReturnType<typeof vi.fn>).mockResolvedValue({
+        hasProject: true,
+        hasMilestone: true,
+        slices: [{ id: "S01", done: false }, { id: "S02", done: true }],
+      });
+      (loadMetricsLedger as ReturnType<typeof vi.fn>).mockResolvedValue({
+        units: [{ slice: "S01", duration: 120 }],
+      });
+      (buildMetricsData as ReturnType<typeof vi.fn>).mockReturnValue({
+        avgSliceDuration: 120,
+        eta: 120,
+      });
+
+      const client = createMockClient();
+      const session = createMockSession({ client: client as any });
+      const { ctx, webview } = createMockDispatchContext(session);
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "get_dashboard",
+      } as WebviewToExtensionMessage);
+
+      expect(loadMetricsLedger).toHaveBeenCalled();
+      expect(buildMetricsData).toHaveBeenCalledWith(
+        expect.objectContaining({ units: expect.any(Array) }),
+        1, // 1 remaining slice (S01 not done)
+      );
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect((dashboardCalls[0][1] as any).data.metrics).toBeDefined();
+    });
+
+    it("sends dashboard when no client is running", async () => {
+      const { buildDashboardData } = await import("./dashboard-parser");
+      (buildDashboardData as ReturnType<typeof vi.fn>).mockResolvedValue({
+        hasProject: true,
+        hasMilestone: true,
+        slices: [],
+      });
+
+      const session = createMockSession({ client: null });
+      const { ctx, webview } = createMockDispatchContext(session);
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "get_dashboard",
+      } as WebviewToExtensionMessage);
+
+      const dashboardCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "dashboard_data"
+      );
+      expect(dashboardCalls.length).toBe(1);
+      // No stats since no client
+      expect((dashboardCalls[0][1] as any).data.stats).toBeUndefined();
+    });
+  });
+
+  describe("delete_session", () => {
+    it("deletes session and refreshes list", async () => {
+      const { listSessions, deleteSession } = await import("./session-list-service");
+      (listSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { path: "/sessions/s1", id: "s1", name: "Session 1", firstMessage: "hi", created: new Date(), modified: new Date(), messageCount: 5 },
+      ]);
+
+      const { ctx, webview } = createMockDispatchContext();
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "delete_session",
+        path: "/sessions/old",
+      } as WebviewToExtensionMessage);
+
+      expect(deleteSession).toHaveBeenCalledWith("/sessions/old");
+      const listCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "session_list"
+      );
+      expect(listCalls.length).toBe(1);
+    });
+
+    it("posts error when delete fails", async () => {
+      const { deleteSession } = await import("./session-list-service");
+      (deleteSession as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("ENOENT"));
+
+      const { ctx, webview } = createMockDispatchContext();
+
+      await handleWebviewMessage(ctx, webview, SESSION_ID, {
+        type: "delete_session",
+        path: "/sessions/missing",
+      } as WebviewToExtensionMessage);
+
+      const errorCalls = (ctx.postToWebview as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === "error"
+      );
+      expect(errorCalls.length).toBe(1);
     });
   });
 });

--- a/src/extension/message-dispatch.ts
+++ b/src/extension/message-dispatch.ts
@@ -115,6 +115,56 @@ async function appendOverrideFile(cwd: string, change: string): Promise<void> {
 }
 
 // ============================================================
+// sendDashboardData — Build and send dashboard data to the webview
+// ============================================================
+
+async function sendDashboardData(
+  ctx: MessageDispatchContext,
+  webview: vscode.Webview,
+  sessionId: string,
+): Promise<void> {
+  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd();
+  try {
+    const data = await buildDashboardData(cwd);
+    // Merge session stats if available
+    if (data) {
+      const client = ctx.getSession(sessionId).client;
+      if (client?.isRunning) {
+        try {
+          const statsResult = await client.getSessionStats() as Record<string, unknown> | null;
+          if (statsResult) {
+            data.stats = {
+              cost: statsResult.cost as number | undefined,
+              tokens: statsResult.tokens as { input: number; output: number; cacheRead: number; cacheWrite: number; total: number } | undefined,
+              toolCalls: statsResult.toolCalls as number | undefined,
+              userMessages: statsResult.userMessages as number | undefined,
+            };
+            ctx.applySessionCostFloor(sessionId, data.stats);
+          }
+        } catch {
+          // Stats not available — that's fine
+        }
+      }
+    }
+    // Merge metrics data if available
+    if (data) {
+      try {
+        const ledger = await loadMetricsLedger(cwd);
+        if (ledger && ledger.units.length > 0) {
+          const remainingSlices = data.slices.filter(s => !s.done).length;
+          data.metrics = buildMetricsData(ledger, remainingSlices);
+        }
+      } catch {
+        // Metrics not available — that's fine
+      }
+    }
+    ctx.postToWebview(webview, { type: "dashboard_data", data } as ExtensionToWebviewMessage);
+  } catch (_err: unknown) {
+    ctx.postToWebview(webview, { type: "dashboard_data", data: null } as ExtensionToWebviewMessage);
+  }
+}
+
+// ============================================================
 // handleWebviewMessage — The entire message dispatch switch
 // ============================================================
 
@@ -217,6 +267,15 @@ export async function handleWebviewMessage(
               await c.prompt(msg.message, images);
               ctx.output.appendLine(`[${sessionId}] Prompt RPC resolved for: "${msg.message.slice(0, 80)}"`);
               startGsdFallbackTimer(ctx.commandFallbackCtx, msg.message.trim(), sessionId, webview);
+
+              // When /gsd status is sent, also show our structured dashboard
+              // since pi's TUI widget doesn't translate to RPC mode.
+              // Also catch /gsd auto with status-related instructions.
+              const trimmed = msg.message.trim();
+              if (/^\s*\/gsd\s+status\b/i.test(trimmed) ||
+                  (/^\s*\/gsd\s+auto\b/i.test(trimmed) && /\bstatus\b/i.test(trimmed))) {
+                sendDashboardData(ctx, webview, sessionId).catch(() => {});
+              }
             } catch (err: any) {
               if (err.message?.includes("streaming")) {
                 const isSlash = msg.message.trimStart().startsWith("/");
@@ -231,6 +290,12 @@ export async function handleWebviewMessage(
                     armGsdFallbackProbe(ctx.commandFallbackCtx, msg.message.trim(), sessionId, webview);
                     await abortAndPrompt(ctx.watchdogCtx, c, webview, msg.message, msg.images);
                     startGsdFallbackTimer(ctx.commandFallbackCtx, msg.message.trim(), sessionId, webview);
+                    // Trigger dashboard for /gsd status in retry path too
+                    const retryTrimmed = msg.message.trim();
+                    if (/^\s*\/gsd\s+status\b/i.test(retryTrimmed) ||
+                        (/^\s*\/gsd\s+auto\b/i.test(retryTrimmed) && /\bstatus\b/i.test(retryTrimmed))) {
+                      sendDashboardData(ctx, webview, sessionId).catch(() => {});
+                    }
                   } else {
                     await c.steer(msg.message, imgs);
                   }
@@ -406,46 +471,7 @@ export async function handleWebviewMessage(
         }
 
         case "get_dashboard": {
-          const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd();
-          try {
-            const data = await buildDashboardData(cwd);
-            // Merge session stats if available
-            if (data) {
-              const client = ctx.getSession(sessionId).client;
-              if (client?.isRunning) {
-                try {
-                  const statsResult = await client.getSessionStats() as Record<string, unknown> | null;
-                  if (statsResult) {
-                    data.stats = {
-                      cost: statsResult.cost as number | undefined,
-                      tokens: statsResult.tokens as { input: number; output: number; cacheRead: number; cacheWrite: number; total: number } | undefined,
-                      toolCalls: statsResult.toolCalls as number | undefined,
-                      userMessages: statsResult.userMessages as number | undefined,
-                    };
-                    ctx.applySessionCostFloor(sessionId, data.stats);
-                  }
-                } catch {
-                  // Stats not available — that's fine
-                }
-              }
-            }
-            // Merge metrics data if available
-            if (data) {
-              try {
-                const ledger = await loadMetricsLedger(cwd);
-                if (ledger && ledger.units.length > 0) {
-                  // Count remaining slices from roadmap
-                  const remainingSlices = data.slices.filter(s => !s.done).length;
-                  data.metrics = buildMetricsData(ledger, remainingSlices);
-                }
-              } catch {
-                // Metrics not available — that's fine
-              }
-            }
-            ctx.postToWebview(webview, { type: "dashboard_data", data } as ExtensionToWebviewMessage);
-          } catch (_err: unknown) {
-            ctx.postToWebview(webview, { type: "dashboard_data", data: null } as ExtensionToWebviewMessage);
-          }
+          await sendDashboardData(ctx, webview, sessionId);
           break;
         }
 
@@ -615,34 +641,6 @@ export async function handleWebviewMessage(
           break;
         }
 
-        case "fork_conversation": {
-          const client = ctx.getSession(sessionId).client;
-          if (client?.isRunning) {
-            try {
-              await client.fork(msg.entryId);
-              ctx.getSession(sessionId).accumulatedCost = 0;
-              ctx.emitStatus({ cost: 0 });
-              const state = await client.getState() as RpcStateResult;
-              const messagesResult = await client.getMessages() as { messages?: AgentMessage[] } | null;
-              const forkResult = await client.getForkMessages() as { messages?: { entryId: string; text: string }[] } | null;
-              ctx.output.appendLine(`[${sessionId}] Forked conversation from entry ${msg.entryId}, ${messagesResult?.messages?.length || 0} messages`);
-              ctx.postToWebview(webview, {
-                type: "session_switched",
-                state: toGsdState(state),
-                messages: messagesResult?.messages || [],
-                forkEntries: forkResult?.messages || [],
-              });
-              if (state?.model) {
-                ctx.emitStatus({ model: (state.model as any).id || (state.model as any).name });
-              }
-            } catch (err: any) {
-              ctx.output.appendLine(`[${sessionId}] Fork failed: ${err.message}`);
-              ctx.postToWebview(webview, { type: "error", message: `Fork failed: ${err.message}` });
-            }
-          }
-          break;
-        }
-
         case "get_session_list": {
           const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd();
           try {
@@ -692,13 +690,11 @@ export async function handleWebviewMessage(
               // Get the new state and messages after switch
               const state = await client.getState() as RpcStateResult;
               const messagesResult = await client.getMessages() as { messages?: AgentMessage[] } | null;
-              const forkResult = await client.getForkMessages() as { messages?: { entryId: string; text: string }[] } | null;
               ctx.output.appendLine(`[${sessionId}] Switched session, ${messagesResult?.messages?.length || 0} messages`);
               ctx.postToWebview(webview, {
                 type: "session_switched",
                 state: toGsdState(state),
                 messages: messagesResult?.messages || [],
-                forkEntries: forkResult?.messages || [],
               });
               // Update status bar
               if (state?.model) {
@@ -834,13 +830,11 @@ export async function handleWebviewMessage(
               ctx.emitStatus({ cost: 0 });
               const state = await client.getState() as RpcStateResult;
               const messagesResult = await client.getMessages() as { messages?: AgentMessage[] } | null;
-              const forkResult = await client.getForkMessages() as { messages?: { entryId: string; text: string }[] } | null;
               ctx.output.appendLine(`[${sessionId}] Resumed last session: ${latest.name || latest.id} (${messagesResult?.messages?.length || 0} messages)`);
               ctx.postToWebview(webview, {
                 type: "session_switched",
                 state: toGsdState(state),
                 messages: messagesResult?.messages || [],
-                forkEntries: forkResult?.messages || [],
               });
               if (state?.model) {
                 ctx.emitStatus({ model: (state.model as any).id || (state.model as any).name });

--- a/src/extension/rpc-client.ts
+++ b/src/extension/rpc-client.ts
@@ -662,11 +662,6 @@ export class GsdRpcClient extends EventEmitter {
     await this.request({ type: "set_session_name", name });
   }
 
-  /** Fork the conversation at a specific message entry, creating a new branch. */
-  async fork(entryId: string): Promise<unknown> {
-    return await this.request({ type: "fork", entryId });
-  }
-
   /** Enable or disable automatic context compaction. */
   async setAutoCompaction(enabled: boolean): Promise<void> {
     await this.request({ type: "set_auto_compaction", enabled });
@@ -690,11 +685,6 @@ export class GsdRpcClient extends EventEmitter {
   /** Set follow-up message delivery mode: `"all"` sends immediately, `"one-at-a-time"` queues. */
   async setFollowUpMode(mode: "all" | "one-at-a-time"): Promise<void> {
     await this.request({ type: "set_follow_up_mode", mode });
-  }
-
-  /** Fetch messages from a forked conversation branch. */
-  async getForkMessages(): Promise<unknown> {
-    return await this.request({ type: "get_fork_messages" });
   }
 
   /**

--- a/src/extension/rpc-events.ts
+++ b/src/extension/rpc-events.ts
@@ -91,16 +91,6 @@ export function handleRpcEvent(
     }
     // Refresh workflow state after each agent turn
     ctx.refreshWorkflowState(webview, sessionId);
-    // Refresh fork entries so newly completed turns get correct server entry IDs
-    const agentEndClient = ctx.getSession(sessionId).client;
-    if (agentEndClient?.isRunning) {
-      agentEndClient.getForkMessages()
-        .then((result: unknown) => {
-          const forkResult = result as { messages?: { entryId: string; text: string }[] } | null;
-          ctx.postToWebview(webview, { type: "fork_entries", entries: forkResult?.messages || [] });
-        })
-        .catch(() => { /* non-critical — fork buttons will lack server IDs until next session switch */ });
-    }
   } else if (eventType === "message_end") {
     const msg = event.message as Record<string, unknown> | undefined;
     const usage = (msg?.usage as { cost?: { total?: number } }) ?? undefined;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,7 +32,6 @@ export type WebviewToExtensionMessage =
   | { type: "compact_context" }
   | { type: "export_html" }
   | { type: "run_bash"; command: string }
-  | { type: "fork_conversation"; entryId: string }
   | { type: "extension_ui_response"; id: string; value?: string; values?: string[]; confirmed?: boolean; cancelled?: boolean }
   | { type: "copy_text"; text: string }
   | { type: "open_file"; path: string }
@@ -102,7 +101,7 @@ export type ExtensionToWebviewMessage =
   | { type: "process_status"; status: ProcessStatus }
   | { type: "process_health"; status: ProcessHealthStatus }
   | { type: "session_list"; sessions: SessionListItem[] }
-  | { type: "session_switched"; state: GsdState; messages: AgentMessage[]; forkEntries?: ForkEntry[] }
+  | { type: "session_switched"; state: GsdState; messages: AgentMessage[] }
   | { type: "session_list_error"; message: string }
   | { type: "update_available"; version: string; currentVersion: string; releaseNotes: string; downloadUrl: string; htmlUrl: string }
   | { type: "workflow_state"; state: WorkflowState | null }
@@ -118,7 +117,6 @@ export type ExtensionToWebviewMessage =
   | { type: "fallback_provider_restored"; provider: string; reason: string }
   | { type: "fallback_chain_exhausted"; reason: string }
   | { type: "session_shutdown" }
-  | { type: "fork_entries"; entries: ForkEntry[] }
   | { type: "extension_error"; extensionPath: string; event: string; error: string }
   | { type: "steer_persisted" }
   | { type: "async_subagent_progress"; toolCallId: string; mode: string; results: Array<{ agent: string; agentSource?: string; task: string; step?: number; exitCode: number; status: string; stopReason?: string; errorMessage?: string; usage?: Record<string, number>; model?: string }> };
@@ -253,16 +251,6 @@ export interface AgentMessage {
   content: unknown;
   timestamp?: number;
   [key: string]: unknown;
-}
-
-/**
- * A fork entry mapping a server-side entry ID to user message text.
- * Used to associate fork buttons with the correct server entry ID.
- * Returned by the `get_fork_messages` RPC method.
- */
-export interface ForkEntry {
-  entryId: string;
-  text: string;
 }
 
 /**

--- a/src/webview/keyboard.ts
+++ b/src/webview/keyboard.ts
@@ -287,15 +287,6 @@ function setupClickHandlers(): void {
       return;
     }
 
-    const forkBtn = target.closest(".gsd-fork-btn") as HTMLElement | null;
-    if (forkBtn) {
-      const entryId = forkBtn.dataset.entryId || forkBtn.closest<HTMLElement>(".gsd-entry")?.dataset.entryId;
-      if (entryId) {
-        vscode.postMessage({ type: "fork_conversation", entryId });
-      }
-      return;
-    }
-
     if (target.classList.contains("gsd-file-link")) {
       const path = target.dataset.path;
       if (path) vscode.postMessage({ type: "open_file", path });

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -584,13 +584,6 @@ function handleMessage(event: MessageEvent): void {
       break;
     }
 
-    case "fork_entries": {
-      state.forkEntries = msg.entries || [];
-      // Update existing fork buttons with server entry IDs
-      renderer.updateForkEntryIds();
-      break;
-    }
-
     case "session_shutdown": {
       state.isStreaming = false;
       state.isCompacting = false;
@@ -808,9 +801,6 @@ function handleMessage(event: MessageEvent): void {
       renderer.clearMessages();
       state.sessionStats = {};
 
-      // Store fork entries for server-side entry ID mapping
-      state.forkEntries = data.forkEntries || [];
-
       // Apply the new state
       if (data.state) {
         state.model = data.state.model || null;
@@ -872,8 +862,6 @@ function renderHistoricalMessages(messages: import("../shared/types").AgentMessa
   // Tool calls are shown as names only (no args, no output).
 
   // Second pass: render user and assistant messages
-  // Track user message index to map fork entries (server entryIds) to assistant turns
-  let userMessageIndex = 0;
   for (const msg of messages) {
     if (msg.role === "user") {
       const text = extractMessageText(msg.content);
@@ -887,7 +875,6 @@ function renderHistoricalMessages(messages: import("../shared/types").AgentMessa
       state.entries.push(entry);
       pruneOldEntries(messagesContainer);
       renderer.renderNewEntry(entry);
-      userMessageIndex++;
     } else if (msg.role === "assistant") {
       const segments: TurnSegment[] = [];
       const turnToolCalls = new Map<string, ToolCallState>();
@@ -937,7 +924,6 @@ function renderHistoricalMessages(messages: import("../shared/types").AgentMessa
         id: nextId(),
         type: "assistant",
         turn,
-        forkEntryId: state.forkEntries[userMessageIndex - 1]?.entryId,
         timestamp: msg.timestamp || Date.now(),
       };
       state.entries.push(entry);

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -151,35 +151,6 @@ export function reattachTurnElement(entryId: string): void {
   }
 }
 
-/**
- * Update fork button data-entry-id attributes with server-side entry IDs.
- * Called when fresh fork entries arrive (e.g. after agent_end).
- * Matches assistant entries to fork entries by user message index order.
- */
-export function updateForkEntryIds(): void {
-  const forkEntries = state.forkEntries;
-  if (!forkEntries.length) return;
-
-  // Walk assistant entries in order and assign fork entry IDs
-  let userIdx = 0;
-  for (const entry of state.entries) {
-    if (entry.type === "user") {
-      userIdx++;
-    } else if (entry.type === "assistant") {
-      const forkEntry = forkEntries[userIdx - 1];
-      if (forkEntry) {
-        entry.forkEntryId = forkEntry.entryId;
-        // Update the DOM fork button's data-entry-id
-        const el = messagesContainer.querySelector(`[data-entry-id="${entry.id}"]`) as HTMLElement | null;
-        const forkBtn = el?.querySelector(".gsd-fork-btn") as HTMLElement | null;
-        if (forkBtn) {
-          forkBtn.dataset.entryId = forkEntry.entryId;
-        }
-      }
-    }
-  }
-}
-
 export function appendToTextSegment(segType: "text" | "thinking", delta: string): void {
   if (!state.currentTurn) return;
 
@@ -434,7 +405,7 @@ export function finalizeCurrentTurn(): void {
       currentTurnElement.classList.add("gsd-stale-echo");
       currentTurnElement.innerHTML = buildStaleEchoHtml(turn);
     } else {
-      currentTurnElement.innerHTML = buildTurnHtml(turn, currentTurnElement.dataset.entryId);
+      currentTurnElement.innerHTML = buildTurnHtml(turn);
     }
   }
 
@@ -474,7 +445,7 @@ function createEntryElement(entry: ChatEntry): HTMLElement {
       el.classList.add("gsd-stale-echo");
       el.innerHTML = buildStaleEchoHtml(entry.turn);
     } else {
-      el.innerHTML = buildTurnHtml(entry.turn, entry.forkEntryId || entry.id);
+      el.innerHTML = buildTurnHtml(entry.turn);
     }
   } else if (entry.type === "system") {
     el.innerHTML = buildSystemHtml(entry);
@@ -545,10 +516,10 @@ function buildStaleEchoHtml(turn: AssistantTurn): string {
     <span class="gsd-stale-echo-icon">↩</span>
     <span class="gsd-stale-echo-text">${escapeHtml(preview)}</span>
   </div>
-  <div class="gsd-stale-echo-full" id="${escapeAttr(panelId)}" hidden>${buildTurnHtml(turn, turn.id)}</div>`;
+  <div class="gsd-stale-echo-full" id="${escapeAttr(panelId)}" hidden>${buildTurnHtml(turn)}</div>`;
 }
 
-function buildTurnHtml(turn: AssistantTurn, entryId?: string): string {
+function buildTurnHtml(turn: AssistantTurn): string {
   let html = "";
 
   const grouped = groupConsecutiveTools(turn.segments, turn.toolCalls);
@@ -610,12 +581,6 @@ function buildTurnHtml(turn: AssistantTurn, entryId?: string): string {
         <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M4 4h8v8H4V4zm1 1v6h6V5H5zm-3-3h8v1H3v7H2V2h8z"/></svg>
         Copy
       </button>`;
-      if (entryId) {
-        html += `<button class="gsd-fork-btn" data-entry-id="${escapeAttr(entryId)}" title="Fork conversation" aria-label="Fork conversation from here">
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M5 3.25a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0ZM2.75 4.5a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5ZM5 12.75a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-2.25 1.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5ZM15.5 12.75a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-2.25 1.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5ZM3.25 4.5a.5.5 0 0 1 .5.5v6.5a.5.5 0 0 1-1 0V5a.5.5 0 0 1 .5-.5ZM3.25 8a.5.5 0 0 1 .5-.5h5.5a2.75 2.75 0 0 1 2.75 2.75v1.25a.5.5 0 0 1-1 0v-1.25A1.75 1.75 0 0 0 9.25 8.5H3.75a.5.5 0 0 1-.5-.5Z"/></svg>
-          Fork
-        </button>`;
-      }
       if (turn.timestamp) {
         html += buildTimestampHtml(turn.timestamp);
       }

--- a/src/webview/state.ts
+++ b/src/webview/state.ts
@@ -5,7 +5,6 @@
 import type {
   ImageAttachment,
   FileAttachment,
-  ForkEntry,
   SessionStats,
   CommandInfo,
   ProcessStatus,
@@ -62,8 +61,6 @@ export interface ChatEntry {
   files?: FileAttachment[];
   // For assistant — a turn with grouped content
   turn?: AssistantTurn;
-  // Server-side fork entry ID — used by fork button to send the correct ID to the server
-  forkEntryId?: string;
   // For system
   systemText?: string;
   systemKind?: "info" | "error" | "warning";
@@ -110,8 +107,6 @@ export interface AppState {
   autoProgressLastUpdate: number;
   // Widget data from setWidget events (keyed by widget key)
   widgetData: Map<string, string[]>;
-  // Fork entry mapping from server — maps user messages to server-side entry IDs for forking
-  forkEntries: ForkEntry[];
 }
 
 /** Tool categorization for icons & color accents */
@@ -193,7 +188,6 @@ export const state: AppState = {
   autoProgress: null,
   autoProgressLastUpdate: 0,
   widgetData: new Map(),
-  forkEntries: [],
 };
 
 // ============================================================
@@ -238,7 +232,6 @@ export function resetState(): void {
   state.autoProgress = null;
   state.autoProgressLastUpdate = 0;
   state.widgetData.clear();
-  state.forkEntries = [];
   entryIdCounter = 0;
   // Reset pruned-entries indicator state
   totalPrunedCount = 0;

--- a/src/webview/styles/entries.css
+++ b/src/webview/styles/entries.css
@@ -355,32 +355,6 @@
   flex-shrink: 0;
 }
 
-.gsd-fork-btn {
-  display: flex;
-  align-items: center;
-  gap: var(--gsd-space-xs);
-  border: none;
-  background: transparent;
-  color: var(--gsd-color-text-muted);
-  cursor: pointer;
-  font-size: var(--gsd-font-size-xs);
-  padding: 2px 8px;
-  border-radius: var(--gsd-radius-sm);
-  transition: background 0.15s, color 0.15s;
-  font-family: var(--gsd-font-family-mono);
-  opacity: 0.6;
-}
-
-.gsd-fork-btn:hover {
-  opacity: 1;
-  background: var(--gsd-color-surface-active);
-  color: var(--gsd-color-text);
-}
-
-.gsd-fork-btn svg {
-  flex-shrink: 0;
-}
-
 .gsd-turn-actions .gsd-timestamp {
   margin-top: 0;
 }


### PR DESCRIPTION
## Problem

When running `/gsd status` or `/gsd auto` with "View status", pi's TUI status widget uses factory functions that are silently dropped in RPC mode (Knowledge #1). This results in the status output rendering as an unformatted wall of text in the webview — all milestones, progress indicators, and phase info crammed into a single paragraph.

## Fix

When `/gsd status` (or `/gsd auto` with "status" keyword) is sent, the extension now also triggers the structured dashboard display — the same rich dashboard shown via `Ctrl+Alt+G`. This renders:
- Milestones as a proper list with ✓/○ indicators
- Progress bars and phase labels
- Session stats (cost, tokens, tool calls)
- Metrics data when available

### Changes
- **Extract `sendDashboardData()` helper** — dashboard building logic was inline in the `get_dashboard` handler; now reusable
- **Detect `/gsd status` and `/gsd auto` + "status"** — triggers dashboard alongside the agent's text response
- **Remove `fork_conversation` feature** — was never fully wired (Knowledge #32: fork entryId is webview-local, not server-side; Knowledge #38: "wired but unreachable" is worse than dead code)
- **Update README badges** — version 0.2.69, gsd-pi compatibility v2.12–v2.40, 850 tests/60%+ coverage

## Testing
- `npm run build` — both extension and webview bundles compile cleanly
- All 54 message-dispatch tests pass
- Pre-existing type errors in test files unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async subagent monitoring and background agent cards; Health widget and Model health indicator; Health tab added to workflow visualiser
  * Steer persistence—auto-mode messages saved and applied to future tasks
  * New `/gsd rate` and `/auto-retry` slash commands; auto-retry UI now shows an abort button

* **Removed Features**
  * Fork conversation and fork-entry controls removed (UI, state and related menu actions)
  * Exported standalone HTML no longer hides fork control elements

* **Documentation**
  * Updated compatibility (v2.12–v2.40), slash command counts and test metrics (850 tests, 60%+ coverage)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->