### PR TITLE
fix: defer parallel batch finalization until message_end arrives

### DIFF
--- a/src/webview/handlers/streaming-handlers.ts
+++ b/src/webview/handlers/streaming-handlers.ts
@@ -12,6 +12,7 @@ import {
   setActiveBatchToolIds,
   getBatchFinalizeTimer,
   setBatchFinalizeTimer,
+  getMessageParallelToolIds,
   setMessageParallelToolIds,
   getLastMessageUsage,
   setLastMessageUsage,
@@ -123,14 +124,16 @@ export function handleMessageUpdate(msg: Msg<'message_update'>): void {
 
     removeSteerNotes();
     const activeBatch = getActiveBatchToolIds();
+    const msgParallel = getMessageParallelToolIds();
     const timer = getBatchFinalizeTimer();
-    if (activeBatch && !timer) {
-      const allDone = [...activeBatch].every(id => {
+    if (activeBatch && msgParallel && !timer) {
+      const fullSet = new Set([...activeBatch, ...msgParallel]);
+      const allDone = [...fullSet].every(id => {
         const t = state.currentTurn?.toolCalls.get(id);
         return t && !t.isRunning;
       });
       if (allDone) {
-        console.debug(`[gsd:parallel] text_delta: finalizing batch (${activeBatch.size} tools) — text arrived`);
+        console.debug(`[gsd:parallel] text_delta: finalizing batch (${fullSet.size} tools) — text arrived`);
         renderer.finalizeParallelBatch(getLastMessageUsage());
         setActiveBatchToolIds(null);
       }

--- a/src/webview/handlers/streaming-handlers.ts
+++ b/src/webview/handlers/streaming-handlers.ts
@@ -3,6 +3,7 @@ type Msg<T extends ExtensionToWebviewMessage['type']> = Extract<ExtensionToWebvi
 import { state, nextId, type ToolCallState } from "../state";
 import * as renderer from "../renderer";
 import { scrollToBottom } from "../helpers";
+import { BATCH_FINALIZE_DELAY_MS } from "../../shared/constants";
 import { announceToScreenReader } from "../a11y";
 import * as uiDialogs from "../ui-dialogs";
 import {
@@ -375,6 +376,19 @@ export function handleMessageEnd(msg: Msg<'message_end'>): void {
       const timer = getBatchFinalizeTimer();
       if (timer) { clearTimeout(timer); setBatchFinalizeTimer(null); }
       renderer.syncBatchState(activeBatch);
+
+      const allDone = [...activeBatch].every(id => {
+        const t = state.currentTurn!.toolCalls.get(id);
+        return t && !t.isRunning;
+      });
+      if (allDone) {
+        setBatchFinalizeTimer(setTimeout(() => {
+          console.debug(`[gsd:parallel] batch FINALIZED (post-message_end) — ${getActiveBatchToolIds()?.size ?? 0} tools`);
+          renderer.finalizeParallelBatch(getLastMessageUsage());
+          setBatchFinalizeTimer(null);
+          setActiveBatchToolIds(null);
+        }, BATCH_FINALIZE_DELAY_MS));
+      }
     } else {
       setMessageParallelToolIds(null);
     }

--- a/src/webview/handlers/tool-execution-handlers.ts
+++ b/src/webview/handlers/tool-execution-handlers.ts
@@ -58,8 +58,8 @@ function renderToolEnd(data: Msg<'tool_execution_end'>): void {
       const t = state.currentTurn?.toolCalls.get(id);
       return t && !t.isRunning;
     });
-    console.debug(`[gsd:parallel] renderToolEnd: id=${data.toolCallId} batchSize=${activeBatch?.size} fullSetSize=${fullSet.size} allDone=${allDone}`);
-    if (allDone) {
+    console.debug(`[gsd:parallel] renderToolEnd: id=${data.toolCallId} batchSize=${activeBatch?.size} fullSetSize=${fullSet.size} allDone=${allDone} hasMessageEnd=${!!msgParallel}`);
+    if (allDone && msgParallel) {
       const timer = getBatchFinalizeTimer();
       if (timer) clearTimeout(timer);
       setBatchFinalizeTimer(setTimeout(() => {


### PR DESCRIPTION
## Summary
- **Root cause:** When 8 parallel tool calls arrive, early-finishing tools triggered the finalize timer before `message_end` delivered the authoritative set of tool IDs — causing premature batch closure (e.g. 3 of 8 captured)
- `renderToolEnd` now only starts the finalize timer after `message_end` has set `messageParallelToolIds`
- `handleMessageEnd` checks if all tools already finished and kicks off finalization immediately if so — no lost batches

## Test plan
- [ ] Trigger 8+ parallel tool calls and verify all render inside the batch container
- [ ] Verify single tool calls still finalize normally
- [ ] Verify `agent_end` safety net still works if `message_end` is delayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parallel tool execution handling — batch finalisation now waits briefly and verifies all parallel tool outputs plus the message-end marker before closing a batch, preventing premature completion and ensuring more reliable, complete results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->