### PR TITLE
fix: parallel batch splitting, context % accuracy, Agent block inclusion

### DIFF
--- a/dist/meta-webview.json
+++ b/dist/meta-webview.json
@@ -514,7 +514,7 @@
       "format": "esm"
     },
     "src/webview/message-handler.ts": {
-      "bytes": 83811,
+      "bytes": 84494,
       "imports": [
         {
           "path": "src/webview/helpers.ts",
@@ -812,7 +812,7 @@
       "imports": [],
       "exports": [],
       "inputs": {},
-      "bytes": 930512
+      "bytes": 931273
     },
     "dist/webview/index.js": {
       "imports": [],
@@ -938,7 +938,7 @@
           "bytesInOutput": 6809
         },
         "src/webview/message-handler.ts": {
-          "bytesInOutput": 27876
+          "bytesInOutput": 28007
         },
         "src/webview/ui-updates.ts": {
           "bytesInOutput": 7858
@@ -947,7 +947,7 @@
           "bytesInOutput": 19106
         }
       },
-      "bytes": 239955
+      "bytes": 240086
     },
     "dist/webview/index.css.map": {
       "imports": [],

--- a/dist/meta-webview.json
+++ b/dist/meta-webview.json
@@ -18,7 +18,7 @@
       "imports": []
     },
     "src/webview/styles/entries.css": {
-      "bytes": 8549,
+      "bytes": 8993,
       "imports": []
     },
     "src/webview/styles/tools.css": {
@@ -302,7 +302,7 @@
       "format": "esm"
     },
     "src/webview/render/streaming.ts": {
-      "bytes": 21120,
+      "bytes": 21485,
       "imports": [
         {
           "path": "marked",
@@ -343,7 +343,7 @@
       "format": "esm"
     },
     "src/webview/renderer.ts": {
-      "bytes": 81609,
+      "bytes": 83281,
       "imports": [
         {
           "path": "src/webview/state.ts",
@@ -514,7 +514,7 @@
       "format": "esm"
     },
     "src/webview/message-handler.ts": {
-      "bytes": 79970,
+      "bytes": 83811,
       "imports": [
         {
           "path": "src/webview/helpers.ts",
@@ -600,7 +600,7 @@
       "format": "esm"
     },
     "src/webview/ui-updates.ts": {
-      "bytes": 15130,
+      "bytes": 15983,
       "imports": [
         {
           "path": "src/webview/helpers.ts",
@@ -812,7 +812,7 @@
       "imports": [],
       "exports": [],
       "inputs": {},
-      "bytes": 921294
+      "bytes": 930512
     },
     "dist/webview/index.js": {
       "imports": [],
@@ -920,7 +920,7 @@
           "bytesInOutput": 151
         },
         "src/webview/renderer.ts": {
-          "bytesInOutput": 31181
+          "bytesInOutput": 31705
         },
         "src/webview/dashboard.ts": {
           "bytesInOutput": 10406
@@ -938,22 +938,22 @@
           "bytesInOutput": 6809
         },
         "src/webview/message-handler.ts": {
-          "bytesInOutput": 27002
+          "bytesInOutput": 27876
         },
         "src/webview/ui-updates.ts": {
-          "bytesInOutput": 7272
+          "bytesInOutput": 7858
         },
         "src/webview/index.ts": {
           "bytesInOutput": 19106
         }
       },
-      "bytes": 237971
+      "bytes": 239955
     },
     "dist/webview/index.css.map": {
       "imports": [],
       "exports": [],
       "inputs": {},
-      "bytes": 269641
+      "bytes": 270427
     },
     "dist/webview/index.css": {
       "imports": [],
@@ -968,7 +968,7 @@
           "bytesInOutput": 10571
         },
         "src/webview/styles/entries.css": {
-          "bytesInOutput": 6328
+          "bytesInOutput": 6724
         },
         "src/webview/styles/tools.css": {
           "bytesInOutput": 15553
@@ -1007,7 +1007,7 @@
           "bytesInOutput": 9942
         }
       },
-      "bytes": 124705
+      "bytes": 125101
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rokket-gsd",
 	"displayName": "Rokket GSD",
 	"description": "AI coding agent by Rokketek — full chat UI, tool execution, model picker, and GSD workflow automation in VS Code",
-	"version": "0.3.37",
+	"version": "0.3.38",
 	"publisher": "rokketek",
 	"license": "MIT",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rokket-gsd",
 	"displayName": "Rokket GSD",
 	"description": "AI coding agent by Rokketek — full chat UI, tool execution, model picker, and GSD workflow automation in VS Code",
-	"version": "0.3.31",
+	"version": "0.3.37",
 	"publisher": "rokketek",
 	"license": "MIT",
 	"repository": {

--- a/src/webview/__tests__/message-handler.test.ts
+++ b/src/webview/__tests__/message-handler.test.ts
@@ -1182,6 +1182,41 @@ describe("message-handler", () => {
       expect(state.sessionStats.tokens?.total).toBe(850);
     });
 
+    it("tracks session totals as monotonic-max from message_end usage", () => {
+      // pi's `message_end.usage` is session-cumulative (see gsd-pi
+      // agent-session getSessionStats — totalInput sums across assistant
+      // messages). Treat every field as monotonic-max so the header never
+      // visibly dips when pi re-emits an earlier snapshot.
+      sendMessage({ type: "agent_start" });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 17, output: 4464, cacheRead: 881636, cacheWrite: 72261 },
+        },
+      });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 50, output: 9100, cacheRead: 1700000, cacheWrite: 50000 },
+        },
+      });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 50, output: 16000, cacheRead: 2100000, cacheWrite: 40000 },
+        },
+      });
+      const t = state.sessionStats.tokens!;
+      expect(t.input).toBe(50);
+      expect(t.output).toBe(16000);
+      expect(t.cacheRead).toBe(2100000);
+      expect(t.cacheWrite).toBe(72261);
+      expect(t.total).toBe(t.input + t.output + t.cacheRead + t.cacheWrite);
+    });
+
     it("accumulates cost from message_end usage", () => {
       sendMessage({ type: "agent_start" });
       sendMessage({
@@ -1194,7 +1229,71 @@ describe("message-handler", () => {
       expect(state.sessionStats.cost).toBe(0.005);
     });
 
-    it("computes contextPercent from usage tokens when cost_update is absent", () => {
+    it("computes contextPercent from perCallUsage.totalTokens when present", () => {
+      // pi's claude-code-cli adapter attaches `perCallUsage` — the last API
+      // call's snapshot. `totalTokens` matches pi's calculateContextTokens().
+      state.sessionStats.contextWindow = 100_000;
+      sendMessage({ type: "agent_start" });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 40000, output: 5000, cacheRead: 10000, cacheWrite: 0 },
+          perCallUsage: { input: 40000, output: 5000, cacheRead: 10000, cacheWrite: 0, totalTokens: 55000 },
+        } as any,
+      });
+      expect(state.sessionStats.contextPercent).toBeCloseTo(55, 5);
+      expect(state.sessionStats.contextTokens).toBe(55000);
+    });
+
+    it("falls back to perCallUsage field sum when totalTokens is missing", () => {
+      state.sessionStats.contextWindow = 100_000;
+      sendMessage({ type: "agent_start" });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 50, output: 500, cacheRead: 40000, cacheWrite: 5000 },
+          perCallUsage: { input: 50, output: 500, cacheRead: 40000, cacheWrite: 5000 },
+        } as any,
+      });
+      expect(state.sessionStats.contextTokens).toBe(45550);
+      expect(state.sessionStats.contextPercent).toBeCloseTo(45.55, 5);
+    });
+
+    it("reflects only the LAST call's perCallUsage across multiple message_end events", () => {
+      // Regression guard for the 91.7% bug: we MUST NOT delta-compute
+      // context from session-cumulative `usage`. Each message_end carries
+      // its own API call's snapshot; the latest one wins.
+      state.sessionStats.contextWindow = 100_000;
+      sendMessage({ type: "agent_start" });
+
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 10000, output: 2000, cacheRead: 0, cacheWrite: 0 },
+          perCallUsage: { input: 10000, output: 2000, cacheRead: 0, cacheWrite: 0, totalTokens: 12000 },
+        } as any,
+      });
+      expect(state.sessionStats.contextPercent).toBe(12);
+
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 30000, output: 4000, cacheRead: 0, cacheWrite: 0 },
+          perCallUsage: { input: 20000, output: 2000, cacheRead: 0, cacheWrite: 0, totalTokens: 22000 },
+        } as any,
+      });
+      expect(state.sessionStats.contextPercent).toBe(22);
+      expect(state.sessionStats.contextTokens).toBe(22000);
+    });
+
+    it("does not update contextPercent when perCallUsage is absent", () => {
+      // Without a per-call snapshot, session-cumulative `usage` alone cannot
+      // yield an honest context %. Leave the last known value intact rather
+      // than invent one from session aggregates.
       state.sessionStats.contextWindow = 100_000;
       sendMessage({ type: "agent_start" });
       sendMessage({
@@ -1204,54 +1303,21 @@ describe("message-handler", () => {
           usage: { input: 40000, output: 5000, cacheRead: 10000, cacheWrite: 0 },
         },
       });
-      // contextTokens = input + cacheRead + cacheWrite = 50000
-      // contextPercent = 50000 / 100000 * 100 = 50
-      expect(state.sessionStats.contextPercent).toBe(50);
-    });
-
-    it("computes contextPercent from per-call message_end.usage (no cumulative deltas)", () => {
-      state.sessionStats.contextWindow = 100_000;
-      sendMessage({
-        type: "cost_update",
-        cumulativeCost: 0.01,
-        tokens: { input: 5000, output: 500, cacheRead: 2000, cacheWrite: 1000 },
-      });
-      // cost_update no longer computes context%
       expect(state.sessionStats.contextPercent).toBeUndefined();
-
-      sendMessage({ type: "agent_start" });
-      // First call: 5000 + 40000 + 5000 = 50000 → 50%
-      sendMessage({
-        type: "message_end",
-        message: {
-          role: "assistant",
-          usage: { input: 5000, output: 500, cacheRead: 40000, cacheWrite: 5000 },
-        },
-      });
-      expect(state.sessionStats.contextPercent).toBe(50);
-
-      // Second call is also per-call: 10000 + 55000 + 5000 = 70000 → 70%
-      sendMessage({
-        type: "message_end",
-        message: {
-          role: "assistant",
-          usage: { input: 10000, output: 1000, cacheRead: 55000, cacheWrite: 5000 },
-        },
-      });
-      expect(state.sessionStats.contextPercent).toBe(70);
+      expect(state.sessionStats.contextTokens).toBeUndefined();
     });
 
-    it("prefers usage.totalTokens when present", () => {
-      state.sessionStats.contextWindow = 100_000;
+    it("updates contextWindow even when perCallUsage is absent", () => {
+      state.model = { id: "claude-sonnet-4-6", name: "Sonnet", provider: "anthropic", contextWindow: 180_000 };
       sendMessage({ type: "agent_start" });
       sendMessage({
         type: "message_end",
         message: {
           role: "assistant",
-          usage: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1, totalTokens: 42000 } as any,
+          usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 },
         },
       });
-      expect(state.sessionStats.contextPercent).toBe(42);
+      expect(state.sessionStats.contextWindow).toBe(180_000);
     });
 
     it("handles message_end with stopReason:error without crashing", () => {

--- a/src/webview/__tests__/parallel-batch-e2e.test.ts
+++ b/src/webview/__tests__/parallel-batch-e2e.test.ts
@@ -1,0 +1,644 @@
+// @vitest-environment jsdom
+//
+// End-to-end parallel-batch tests — drives real message-handler + real renderer
+// (NO renderer mock). Asserts on the actual DOM shape to catch regressions
+// where event sequences that should form one parallel batch instead render as
+// individual rows (or merge into one giant block across messages).
+//
+// Ground truth for pi's event shape (see M026 investigation):
+//   - N parallel tool_use blocks in one assistant message share a single
+//     message_start → message_end pair.
+//   - message_end.message.content carries the authoritative parallel tool-id
+//     list (only events where grouping is definitive).
+//   - tool_execution_start / tool_execution_end are emitted per-tool, back-to-back.
+//   - Different assistant messages (e.g. reasoning between waves) get
+//     distinct message_start / message_end pairs — these MUST split batches.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { state } from "../state";
+
+// Mock only peripheral modules — keep the real renderer so DOM assertions work.
+vi.mock("../session-history", () => ({
+  setCurrentSessionId: vi.fn(),
+  updateSessions: vi.fn(),
+  showError: vi.fn(),
+  hide: vi.fn(),
+}));
+vi.mock("../slash-menu", () => ({ isVisible: vi.fn(() => false), show: vi.fn() }));
+vi.mock("../model-picker", () => ({ isVisible: vi.fn(() => false), render: vi.fn() }));
+vi.mock("../thinking-picker", () => ({ refresh: vi.fn() }));
+vi.mock("../ui-dialogs", () => ({
+  hasPending: vi.fn(() => false),
+  expireAllPending: vi.fn(),
+  handleRequest: vi.fn(),
+}));
+vi.mock("../toasts", () => ({ show: vi.fn() }));
+vi.mock("../dashboard", () => ({
+  renderDashboard: vi.fn(),
+  updateWelcomeScreen: vi.fn(),
+}));
+vi.mock("../auto-progress", () => ({ update: vi.fn() }));
+vi.mock("../visualizer", () => ({ isVisible: vi.fn(() => false), updateData: vi.fn() }));
+vi.mock("../file-handling", () => ({ addFileAttachments: vi.fn() }));
+vi.mock("../keyboard", () => ({
+  setChangelogHandlers: vi.fn(),
+  getChangelogTriggerEl: vi.fn(() => null),
+  dismissChangelog: vi.fn(),
+}));
+vi.mock("../a11y", () => ({
+  createFocusTrap: vi.fn(() => vi.fn()),
+  saveFocus: vi.fn(() => null),
+  restoreFocus: vi.fn(),
+  announceToScreenReader: vi.fn(),
+}));
+
+import { init } from "../message-handler";
+import * as renderer from "../renderer";
+
+function sendMessage(data: Record<string, unknown>): void {
+  window.dispatchEvent(new MessageEvent("message", { data }));
+}
+
+function msgEndWithTools(toolBlocks: Array<{ id: string; name: string; type?: string }>): Record<string, unknown> {
+  return {
+    type: "message_end",
+    message: {
+      role: "assistant",
+      content: toolBlocks.map((b) => ({
+        type: b.type ?? "tool_use",
+        id: b.id,
+        name: b.name,
+        input: {},
+      })),
+    },
+  };
+}
+
+function resetState(): void {
+  state.entries = [];
+  state.currentTurn = null;
+  state.isStreaming = false;
+  state.isCompacting = false;
+  state.isRetrying = false;
+  state.model = null;
+  state.thinkingLevel = null;
+  state.processStatus = "stopped";
+  state.processHealth = "responsive";
+  state.sessionStats = {};
+  state.commands = [];
+  state.commandsLoaded = false;
+  state.availableModels = [];
+  state.modelsLoaded = false;
+  state.modelsRequested = false;
+  state.loadedSkills = new Set<string>();
+}
+
+describe("parallel batch rendering (E2E, real renderer)", () => {
+  let messagesContainer: HTMLElement;
+  let welcomeScreen: HTMLElement;
+  let promptInput: HTMLTextAreaElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    messagesContainer = document.createElement("div");
+    messagesContainer.id = "messages";
+    welcomeScreen = document.createElement("div");
+    promptInput = document.createElement("textarea") as HTMLTextAreaElement;
+    document.body.appendChild(messagesContainer);
+    document.body.appendChild(welcomeScreen);
+    document.body.appendChild(promptInput);
+
+    resetState();
+    vi.clearAllMocks();
+
+    renderer.init({ messagesContainer, welcomeScreen });
+    init({
+      vscode: { postMessage: vi.fn() },
+      messagesContainer,
+      welcomeScreen,
+      promptInput,
+      updateAllUI: vi.fn(),
+      updateHeaderUI: vi.fn(),
+      updateFooterUI: vi.fn(),
+      updateInputUI: vi.fn(),
+      updateOverlayIndicators: vi.fn(),
+      updateWorkflowBadge: vi.fn(),
+      handleModelRouted: vi.fn(),
+      autoResize: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    resetState();
+  });
+
+  it("5 parallel tools in one message render as one batch container", () => {
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    const tools = [
+      { id: "t1", name: "Bash" },
+      { id: "t2", name: "Bash" },
+      { id: "t3", name: "Grep" },
+      { id: "t4", name: "Read" },
+      { id: "t5", name: "Read" },
+    ];
+
+    // Simulate streaming toolcall_start deltas for each tool (creates segments)
+    for (const t of tools) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+
+    // message_end with all 5 as tool_use blocks — authoritative parallel set
+    sendMessage(msgEndWithTools(tools));
+
+    // Back-to-back tool_execution_start events (parallel dispatch)
+    for (const t of tools) {
+      sendMessage({
+        type: "tool_execution_start",
+        toolCallId: t.id,
+        toolName: t.name,
+        args: {},
+      });
+    }
+
+    // All 5 segments should live inside exactly one parallel batch container.
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(1);
+    const batch = batches[0];
+    const segments = batch.querySelectorAll(".gsd-parallel-batch-content .gsd-tool-segment");
+    expect(segments.length).toBe(5);
+
+    // No tool segments should be loose (outside any batch) inside the turn.
+    const looseSegments = messagesContainer.querySelectorAll(
+      ".gsd-assistant-turn > .gsd-tool-segment",
+    );
+    expect(looseSegments.length).toBe(0);
+  });
+
+  it("5 parallel tools delivered via tool_execution_start only (no streaming deltas) still form one batch", () => {
+    // Some providers (external SDK mode) skip content_block streaming and emit
+    // tool_execution_start events directly. The batch must still form.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    const tools = [
+      { id: "u1", name: "Bash" },
+      { id: "u2", name: "Bash" },
+      { id: "u3", name: "Grep" },
+      { id: "u4", name: "Read" },
+      { id: "u5", name: "Read" },
+    ];
+
+    // message_end FIRST with full parallel set
+    sendMessage(msgEndWithTools(tools));
+
+    // Then back-to-back tool_execution_start events
+    for (const t of tools) {
+      sendMessage({
+        type: "tool_execution_start",
+        toolCallId: t.id,
+        toolName: t.name,
+        args: {},
+      });
+    }
+
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(1);
+    const segments = batches[0].querySelectorAll(
+      ".gsd-parallel-batch-content .gsd-tool-segment",
+    );
+    expect(segments.length).toBe(5);
+  });
+
+  it("two sequential messages each with 3 tools render as TWO batches, not one", () => {
+    // Ground truth: two separate assistant messages with no overlap = two batches.
+    sendMessage({ type: "agent_start" });
+
+    // Message 1
+    sendMessage({ type: "message_start" });
+    const wave1 = [
+      { id: "a1", name: "Bash" },
+      { id: "a2", name: "Bash" },
+      { id: "a3", name: "Grep" },
+    ];
+    sendMessage(msgEndWithTools(wave1));
+    for (const t of wave1) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave1) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 10,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Message 2 — fresh message_start should split batches
+    sendMessage({ type: "message_start" });
+    const wave2 = [
+      { id: "b1", name: "Read" },
+      { id: "b2", name: "Read" },
+      { id: "b3", name: "Grep" },
+    ];
+    sendMessage(msgEndWithTools(wave2));
+    for (const t of wave2) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(2);
+
+    // Each batch should hold its own wave's tools
+    const allBatchIds = Array.from(batches).map((b) =>
+      Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]")).map(
+        (el) => el.dataset.toolId,
+      ),
+    );
+    // One batch has all a*, the other has all b*
+    const flat = allBatchIds.flat().sort();
+    expect(flat).toEqual(["a1", "a2", "a3", "b1", "b2", "b3"]);
+
+    const aBatch = allBatchIds.find((ids) => ids.some((id) => id!.startsWith("a")))!;
+    const bBatch = allBatchIds.find((ids) => ids.some((id) => id!.startsWith("b")))!;
+    expect(aBatch.every((id) => id!.startsWith("a"))).toBe(true);
+    expect(bBatch.every((id) => id!.startsWith("b"))).toBe(true);
+  });
+
+  it("narration between parallel waves in one message splits into two batches", () => {
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    // Wave 1 (3 tools), then narration, then wave 2 (2 tools) — all in one message
+    const wave1 = [
+      { id: "w1-1", name: "Bash" },
+      { id: "w1-2", name: "Bash" },
+      { id: "w1-3", name: "Grep" },
+    ];
+    for (const t of wave1) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave1) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 10,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Narration chunk between waves (thought-cycle boundary)
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Now checking the next set." },
+    });
+
+    const wave2 = [
+      { id: "w2-1", name: "Read" },
+      { id: "w2-2", name: "Read" },
+    ];
+    for (const t of wave2) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    // Single message_end with ALL 5 tools as content blocks — but post-seal
+    // filtering should have already split them into two batches via narration.
+    sendMessage(msgEndWithTools([...wave1, ...wave2]));
+
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(2);
+  });
+
+  it("claude-code external SDK sequence: 5 tools then 5 follow-up turns each with 1 tool → 2+ batches, not 1", () => {
+    // Ground truth per M026 Explore report (gsd-pi external SDK mode):
+    //   message_start (assistant #1)
+    //   message_end (assistant #1 with 5 tool_use blocks)
+    //   tool_execution_start × 5, tool_execution_end × 5
+    //   message_start/message_end × 5 (tool result messages)
+    //   message_start (assistant #2)
+    //   message_end (assistant #2 with 1 tool_use)
+    //   tool_execution_start/end for that tool
+    //   [repeat for assistant #3, #4, #5]
+    //
+    // Expected DOM: the first 5 tools form ONE parallel batch. Each follow-up
+    // single-tool response is a lone segment (not wrapped in a batch). So we
+    // expect exactly 1 .gsd-parallel-batch (containing 5 segments) and
+    // additional loose single-tool segments for the 5 follow-up turns.
+    sendMessage({ type: "agent_start" });
+
+    // ── Assistant response #1: 5 parallel tools ──
+    sendMessage({ type: "message_start" });
+    const wave1 = [
+      { id: "w1-t1", name: "Bash" },
+      { id: "w1-t2", name: "Bash" },
+      { id: "w1-t3", name: "Grep" },
+      { id: "w1-t4", name: "Read" },
+      { id: "w1-t5", name: "Read" },
+    ];
+    sendMessage(msgEndWithTools(wave1));
+    for (const t of wave1) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave1) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 10,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+    // Five tool-result user messages — each is its own message_start/end pair
+    for (let i = 0; i < 5; i++) {
+      sendMessage({ type: "message_start" });
+      sendMessage({
+        type: "message_end",
+        message: { role: "user", content: [{ type: "tool_result", toolUseId: wave1[i].id }] },
+      });
+    }
+
+    // ── Follow-up turns #2..#5, each a single-tool assistant response ──
+    for (let turn = 2; turn <= 5; turn++) {
+      sendMessage({ type: "message_start" });
+      const tool = { id: `w${turn}-t1`, name: "Bash" };
+      sendMessage(msgEndWithTools([tool]));
+      sendMessage({ type: "tool_execution_start", toolCallId: tool.id, toolName: tool.name, args: {} });
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: tool.id,
+        isError: false,
+        durationMs: 10,
+        result: { content: [{ text: "ok" }] },
+      });
+      // Tool-result user message
+      sendMessage({ type: "message_start" });
+      sendMessage({
+        type: "message_end",
+        message: { role: "user", content: [{ type: "tool_result", toolUseId: tool.id }] },
+      });
+    }
+
+    // Expect: exactly ONE .gsd-parallel-batch containing the 5 wave1 tools.
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(1);
+    const batchSegments = batches[0].querySelectorAll(
+      ".gsd-parallel-batch-content .gsd-tool-segment",
+    );
+    expect(batchSegments.length).toBe(5);
+    const batchIds = Array.from(batchSegments)
+      .map((el) => (el as HTMLElement).dataset.toolId!)
+      .sort();
+    expect(batchIds).toEqual(["w1-t1", "w1-t2", "w1-t3", "w1-t4", "w1-t5"]);
+
+    // The 4 follow-up single-tool responses must NOT be inside the batch
+    for (const id of ["w2-t1", "w3-t1", "w4-t1", "w5-t1"]) {
+      const seg = messagesContainer.querySelector(`.gsd-tool-segment[data-tool-id="${id}"]`);
+      expect(seg).not.toBeNull();
+      // The segment must not be a descendant of any .gsd-parallel-batch
+      expect(seg!.closest(".gsd-parallel-batch")).toBeNull();
+    }
+  });
+
+  it("mixed Bash + Agent parallel tools (serverToolUse blocks) render in one batch", () => {
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    // 2 Bash + 2 Agent server-side tools in one message
+    const tools = [
+      { id: "bh-1", name: "Bash", type: "tool_use" as const },
+      { id: "bh-2", name: "Bash", type: "tool_use" as const },
+      { id: "ag-1", name: "Agent", type: "serverToolUse" as const },
+      { id: "ag-2", name: "Agent", type: "serverToolUse" as const },
+    ];
+
+    // Only the regular tool_use blocks emit tool_execution_start; serverToolUse
+    // blocks complete server-side and arrive only in message_end content.
+    for (const t of tools) {
+      if (t.type === "tool_use") {
+        sendMessage({
+          type: "message_update",
+          assistantMessageEvent: {
+            type: "toolcall_start",
+            toolCall: { type: "toolCall", id: t.id, name: t.name },
+            contentIndex: 0,
+            partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+          },
+        });
+      }
+    }
+
+    sendMessage(msgEndWithTools(tools));
+
+    for (const t of tools) {
+      if (t.type === "tool_use") {
+        sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+      }
+    }
+
+    // All four (2 Bash + 2 Agent) should be in one batch
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(1);
+    const segments = batches[0].querySelectorAll(
+      ".gsd-parallel-batch-content .gsd-tool-segment",
+    );
+    expect(segments.length).toBe(4);
+    const ids = Array.from(segments).map((el) => (el as HTMLElement).dataset.toolId).sort();
+    expect(ids).toEqual(["ag-1", "ag-2", "bh-1", "bh-2"]);
+  });
+
+  it("PRODUCTION BUG: sequential waves with NO intermediate message_start must split into separate batches", () => {
+    // Reproduces the real-world bug seen in claude-code external SDK mode:
+    // gsd-pi coalesces the SDK stream and does NOT emit a fresh message_start
+    // between sequential assistant responses within one turn. Each response
+    // arrives as its own message_end with tool_use blocks, but no delimiter.
+    // Pre-fix behaviour: all tools merge into one giant batch ("162 tools...").
+    // Post-fix behaviour: each wave's tools must live in its own batch.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" }); // only ONE for the whole turn
+
+    // Wave 1: 3 tools dispatched, completed
+    const wave1 = [
+      { id: "p1-t1", name: "Bash" },
+      { id: "p1-t2", name: "Bash" },
+      { id: "p1-t3", name: "Grep" },
+    ];
+    sendMessage(msgEndWithTools(wave1));
+    for (const t of wave1) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave1) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 10,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Wave 2 arrives immediately — NO message_start between waves.
+    // (pi in external SDK mode did not emit one.) message_end carries only
+    // the new wave's tools; they must NOT be absorbed into wave 1's batch.
+    const wave2 = [
+      { id: "p2-t1", name: "Read" },
+      { id: "p2-t2", name: "Read" },
+      { id: "p2-t3", name: "Grep" },
+    ];
+    sendMessage(msgEndWithTools(wave2));
+    for (const t of wave2) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave2) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 10,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Wave 3 — another cycle, still no message_start.
+    const wave3 = [
+      { id: "p3-t1", name: "Bash" },
+      { id: "p3-t2", name: "Bash" },
+    ];
+    sendMessage(msgEndWithTools(wave3));
+    for (const t of wave3) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    // Three distinct waves → three distinct batches
+    expect(batches.length).toBe(3);
+
+    // Each batch should hold only its own wave's tools
+    const batchIds = Array.from(batches).map((b) =>
+      Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+        .map((el) => el.dataset.toolId!)
+        .sort(),
+    );
+    const p1 = batchIds.find((ids) => ids.some((id) => id.startsWith("p1-")))!;
+    const p2 = batchIds.find((ids) => ids.some((id) => id.startsWith("p2-")))!;
+    const p3 = batchIds.find((ids) => ids.some((id) => id.startsWith("p3-")))!;
+    expect(p1).toEqual(["p1-t1", "p1-t2", "p1-t3"]);
+    expect(p2).toEqual(["p2-t1", "p2-t2", "p2-t3"]);
+    expect(p3).toEqual(["p3-t1", "p3-t2"]);
+  });
+
+  it("PRODUCTION BUG (timing variant): message_end for wave 2 arrives BEFORE tool_execution_end for wave 1 — must still split", () => {
+    // A subtler variant: wave 1 tools are still "running" (no tool_execution_end
+    // yet) when message_end for wave 2 arrives. The stale-batch check at
+    // message_end bails out because activeBatchToolIds still has running
+    // members, so wave 2 tools get merged into wave 1's batch. This is likely
+    // the real-world bug: long-running tools (Agent/Task) never emit
+    // tool_execution_end, so their ids are "always running" in the batch set.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    // Wave 1: 3 tools START but never complete (simulate long-running Agents)
+    const wave1 = [
+      { id: "q1-t1", name: "Agent", type: "serverToolUse" as const },
+      { id: "q1-t2", name: "Agent", type: "serverToolUse" as const },
+      { id: "q1-t3", name: "Agent", type: "serverToolUse" as const },
+    ];
+    sendMessage(msgEndWithTools(wave1));
+    // serverToolUse blocks never emit tool_execution_start/end — they are
+    // synthesized from message_end and marked as already-complete. But the
+    // batch tracking still treats them as in-batch. Next wave must NOT merge.
+
+    // Wave 2: arrives next, NO message_start between.
+    const wave2 = [
+      { id: "q2-t1", name: "Read" },
+      { id: "q2-t2", name: "Read" },
+    ];
+    sendMessage(msgEndWithTools(wave2));
+    for (const t of wave2) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(2);
+    const batchIds = Array.from(batches).map((b) =>
+      Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+        .map((el) => el.dataset.toolId!)
+        .sort(),
+    );
+    const q1 = batchIds.find((ids) => ids.some((id) => id.startsWith("q1-")))!;
+    const q2 = batchIds.find((ids) => ids.some((id) => id.startsWith("q2-")))!;
+    expect(q1).toEqual(["q1-t1", "q1-t2", "q1-t3"]);
+    expect(q2).toEqual(["q2-t1", "q2-t2"]);
+  });
+
+  it("PRODUCTION BUG (still-running variant): wave 2 message_end while wave 1 tools still running — split on disjoint tool-id sets", () => {
+    // Most likely the actual production trigger. gsd-pi's external SDK adapter
+    // emits message_end for a new assistant response before the previous
+    // assistant response's long-running tools have emitted tool_execution_end.
+    // The existing stale-batch guard requires hasRunningMember=false, so it
+    // refuses to split. Fix: if the new message_end tool-id set is COMPLETELY
+    // DISJOINT from the current batch, treat that as a wave boundary even if
+    // the prior wave's tools are still running.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    // Wave 1: tool_execution_start fires but NO tool_execution_end yet
+    const wave1 = [
+      { id: "r1-t1", name: "Bash" },
+      { id: "r1-t2", name: "Bash" },
+    ];
+    sendMessage(msgEndWithTools(wave1));
+    for (const t of wave1) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    // Wave 2 message_end arrives while wave1 tools still running, no new message_start.
+    const wave2 = [
+      { id: "r2-t1", name: "Grep" },
+      { id: "r2-t2", name: "Grep" },
+    ];
+    sendMessage(msgEndWithTools(wave2));
+    for (const t of wave2) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(2);
+    const batchIds = Array.from(batches).map((b) =>
+      Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+        .map((el) => el.dataset.toolId!)
+        .sort(),
+    );
+    const r1 = batchIds.find((ids) => ids.some((id) => id.startsWith("r1-")))!;
+    const r2 = batchIds.find((ids) => ids.some((id) => id.startsWith("r2-")))!;
+    expect(r1).toEqual(["r1-t1", "r1-t2"]);
+    expect(r2).toEqual(["r2-t1", "r2-t2"]);
+  });
+});

--- a/src/webview/__tests__/parallel-batch-e2e.test.ts
+++ b/src/webview/__tests__/parallel-batch-e2e.test.ts
@@ -51,7 +51,7 @@ vi.mock("../a11y", () => ({
   announceToScreenReader: vi.fn(),
 }));
 
-import { init } from "../message-handler";
+import { init, cleanup } from "../message-handler";
 import * as renderer from "../renderer";
 
 function sendMessage(data: Record<string, unknown>): void {
@@ -128,6 +128,7 @@ describe("parallel batch rendering (E2E, real renderer)", () => {
   });
 
   afterEach(() => {
+    cleanup();
     resetState();
   });
 
@@ -427,7 +428,10 @@ describe("parallel batch rendering (E2E, real renderer)", () => {
     }
   });
 
-  it("mixed Bash + Agent parallel tools (serverToolUse blocks) render in one batch", () => {
+  it.each([
+    ["serverToolUse"],
+    ["server_tool_use"],
+  ])("mixed Bash + Agent parallel tools (%s blocks) render in one batch", (serverToolUseType) => {
     sendMessage({ type: "agent_start" });
     sendMessage({ type: "message_start" });
 
@@ -435,11 +439,11 @@ describe("parallel batch rendering (E2E, real renderer)", () => {
     const tools = [
       { id: "bh-1", name: "Bash", type: "tool_use" as const },
       { id: "bh-2", name: "Bash", type: "tool_use" as const },
-      { id: "ag-1", name: "Agent", type: "serverToolUse" as const },
-      { id: "ag-2", name: "Agent", type: "serverToolUse" as const },
+      { id: "ag-1", name: "Agent", type: serverToolUseType },
+      { id: "ag-2", name: "Agent", type: serverToolUseType },
     ];
 
-    // Only the regular tool_use blocks emit tool_execution_start; serverToolUse
+    // Only the regular tool_use blocks emit tool_execution_start; server tool
     // blocks complete server-side and arrive only in message_end content.
     for (const t of tools) {
       if (t.type === "tool_use") {

--- a/src/webview/handlers/__tests__/streaming-handlers.test.ts
+++ b/src/webview/handlers/__tests__/streaming-handlers.test.ts
@@ -390,6 +390,41 @@ describe("streaming-handlers", () => {
       expect(state.sessionStats.tokens?.total).toBe(850);
     });
 
+    it("tracks session totals as monotonic-max from message_end usage", () => {
+      // pi's `message_end.usage` is a session-wide running aggregate (see
+      // gsd-pi agent-session.ts getSessionStats — totalInput sums across all
+      // assistant messages). Treat each field as monotonic-max so the header
+      // never visibly dips between turns.
+      sendMessage({ type: "agent_start" });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 17, output: 4464, cacheRead: 881636, cacheWrite: 72261 },
+        },
+      });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 50, output: 9100, cacheRead: 1700000, cacheWrite: 50000 },
+        },
+      });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 50, output: 16000, cacheRead: 2100000, cacheWrite: 40000 },
+        },
+      });
+      const t = state.sessionStats.tokens!;
+      expect(t.input).toBe(50);
+      expect(t.output).toBe(16000);
+      expect(t.cacheRead).toBe(2100000);
+      expect(t.cacheWrite).toBe(72261);
+      expect(t.total).toBe(t.input + t.output + t.cacheRead + t.cacheWrite);
+    });
+
     it("accumulates cost from message_end usage", () => {
       sendMessage({ type: "agent_start" });
       sendMessage({
@@ -402,7 +437,10 @@ describe("streaming-handlers", () => {
       expect(state.sessionStats.cost).toBe(0.005);
     });
 
-    it("computes contextPercent from usage tokens when cost_update is absent", () => {
+    it("computes contextPercent from perCallUsage.totalTokens when present", () => {
+      // pi's claude-code-cli adapter attaches `perCallUsage` — the last API
+      // call's snapshot. `totalTokens` is the authoritative value (matches
+      // pi's calculateContextTokens exactly).
       state.sessionStats.contextWindow = 100_000;
       sendMessage({ type: "agent_start" });
       sendMessage({
@@ -410,53 +448,92 @@ describe("streaming-handlers", () => {
         message: {
           role: "assistant",
           usage: { input: 40000, output: 5000, cacheRead: 10000, cacheWrite: 0 },
+          perCallUsage: { input: 40000, output: 5000, cacheRead: 10000, cacheWrite: 0, totalTokens: 55000 },
         },
       });
-      expect(state.sessionStats.contextPercent).toBe(50);
+      expect(state.sessionStats.contextPercent).toBeCloseTo(55, 5);
+      expect(state.sessionStats.contextTokens).toBe(55000);
     });
 
-    it("computes contextPercent from per-call message_end.usage (no cumulative deltas)", () => {
-      state.sessionStats.contextWindow = 100_000;
-      sendMessage({
-        type: "cost_update",
-        cumulativeCost: 0.01,
-        tokens: { input: 5000, output: 500, cacheRead: 2000, cacheWrite: 1000 },
-      });
-
-      sendMessage({ type: "agent_start" });
-      // First call: 5000 + 40000 + 5000 = 50000 → 50%
-      sendMessage({
-        type: "message_end",
-        message: {
-          role: "assistant",
-          usage: { input: 5000, output: 500, cacheRead: 40000, cacheWrite: 5000 },
-        },
-      });
-      expect(state.sessionStats.contextPercent).toBe(50);
-
-      // Second call is ALSO per-call (not cumulative): 10000 + 55000 + 5000 = 70000 → 70%
-      sendMessage({
-        type: "message_end",
-        message: {
-          role: "assistant",
-          usage: { input: 10000, output: 1000, cacheRead: 55000, cacheWrite: 5000 },
-        },
-      });
-      expect(state.sessionStats.contextPercent).toBe(70);
-    });
-
-    it("prefers usage.totalTokens when present", () => {
+    it("falls back to perCallUsage field sum when totalTokens is missing", () => {
       state.sessionStats.contextWindow = 100_000;
       sendMessage({ type: "agent_start" });
       sendMessage({
         type: "message_end",
         message: {
           role: "assistant",
-          // totalTokens wins over the component sum
-          usage: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1, totalTokens: 42000 },
+          usage: { input: 50, output: 500, cacheRead: 40000, cacheWrite: 5000 },
+          // No totalTokens — handler sums input+output+cacheRead+cacheWrite = 45550.
+          perCallUsage: { input: 50, output: 500, cacheRead: 40000, cacheWrite: 5000 },
         },
       });
-      expect(state.sessionStats.contextPercent).toBe(42);
+      expect(state.sessionStats.contextTokens).toBe(45550);
+      expect(state.sessionStats.contextPercent).toBeCloseTo(45.55, 5);
+    });
+
+    it("reflects only the LAST call's perCallUsage across multiple message_end events", () => {
+      // The 91.7% regression was caused by delta-computing from `usage`
+      // (session-cumulative). With perCallUsage each message_end carries the
+      // exact pressure of its own API call — so multi-message turns do not
+      // balloon the displayed percentage.
+      state.sessionStats.contextWindow = 100_000;
+      sendMessage({ type: "agent_start" });
+
+      // Internal call 1: 10000 → 10%
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 10000, output: 2000, cacheRead: 0, cacheWrite: 0 },
+          perCallUsage: { input: 10000, output: 2000, cacheRead: 0, cacheWrite: 0, totalTokens: 12000 },
+        },
+      });
+      expect(state.sessionStats.contextPercent).toBe(12);
+
+      // Internal call 2: 20000 → 20% (NOT 32% — per-call replaces, not sums)
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 30000, output: 4000, cacheRead: 0, cacheWrite: 0 },
+          perCallUsage: { input: 20000, output: 2000, cacheRead: 0, cacheWrite: 0, totalTokens: 22000 },
+        },
+      });
+      expect(state.sessionStats.contextPercent).toBe(22);
+      expect(state.sessionStats.contextTokens).toBe(22000);
+    });
+
+    it("does not update contextPercent when perCallUsage is absent", () => {
+      // Without a per-call snapshot, session-cumulative `usage` alone cannot
+      // yield an honest context %. Leave the last known value intact rather
+      // than invent one from session aggregates.
+      state.sessionStats.contextWindow = 100_000;
+      sendMessage({ type: "agent_start" });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          // No perCallUsage — legacy/upstream pi without the patch.
+          usage: { input: 40000, output: 5000, cacheRead: 10000, cacheWrite: 0 },
+        },
+      });
+      expect(state.sessionStats.contextPercent).toBeUndefined();
+      expect(state.sessionStats.contextTokens).toBeUndefined();
+    });
+
+    it("updates contextWindow even when perCallUsage is absent", () => {
+      // Context window resolution is independent of per-call data — we still
+      // want header chrome to know the model's capacity.
+      state.model = { id: "claude-sonnet-4-6", name: "Sonnet", provider: "anthropic", contextWindow: 180_000 };
+      sendMessage({ type: "agent_start" });
+      sendMessage({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 },
+        },
+      });
+      expect(state.sessionStats.contextWindow).toBe(180_000);
     });
 
     it("handles message_end with stopReason:error without crashing", () => {

--- a/src/webview/handlers/streaming-handlers.ts
+++ b/src/webview/handlers/streaming-handlers.ts
@@ -384,8 +384,18 @@ export function handleMessageEnd(msg: Msg<'message_end'>): void {
   if (endMsg?.content && state.currentTurn) {
     const blocks = Array.isArray(endMsg.content) ? endMsg.content as Array<Record<string, unknown>> : [];
     console.debug(`[gsd:parallel] message_end: ${blocks.length} content blocks, types=[${blocks.map(b => b.type).join(",")}]`);
+    // Include server-executed tool blocks — Agent/Task dispatch and web_search
+    // arrive as `serverToolUse` in pi's content stream and must participate in
+    // parallel batches, otherwise the visible tool count undercounts reality.
+    const toolBlockTypes = new Set([
+      "tool_use",
+      "toolCall",
+      "tool-use",
+      "serverToolUse",
+      "server_tool_use",
+    ]);
     const toolIds = blocks
-      .filter(b => b.type === "tool_use" || b.type === "toolCall" || b.type === "tool-use")
+      .filter(b => toolBlockTypes.has(b.type as string))
       .map(b => b.id)
       .filter(Boolean) as string[];
     console.debug(`[gsd:parallel] message_end: ${toolIds.length} tool IDs found`);
@@ -455,34 +465,56 @@ export function handleMessageEnd(msg: Msg<'message_end'>): void {
       const u = endMsg.usage;
       setLastMessageUsage(u);
 
+      // pi's claude-code-cli adapter exposes a `perCallUsage` field on the
+      // assistant message carrying the *last* API call's usage snapshot
+      // (input, output, cacheRead, cacheWrite, totalTokens). That is the
+      // authoritative signal for context window pressure — `usage` is a
+      // session-wide running aggregate, not per-call.
+      const perCall = (endMsg as Record<string, unknown>).perCallUsage as
+        | { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; totalTokens?: number }
+        | undefined;
+
       if (!getHasCostUpdateSource()) {
+        // cost_update is the authoritative session-total source in v2.
+        // When absent (older providers), mirror pi's session-stat behaviour:
+        // `usage` here is already cumulative across the session for
+        // assistant messages, so take monotonic-max rather than accumulate.
+        const curIn = u.input || 0;
+        const curOut = u.output || 0;
+        const curCR = u.cacheRead || 0;
+        const curCW = u.cacheWrite || 0;
         if (!state.sessionStats.tokens) {
           state.sessionStats.tokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
         }
         const t = state.sessionStats.tokens;
-        t.input += u.input || 0;
-        t.output += u.output || 0;
-        t.cacheRead += u.cacheRead || 0;
-        t.cacheWrite += u.cacheWrite || 0;
+        t.input = Math.max(t.input, curIn);
+        t.output = Math.max(t.output, curOut);
+        t.cacheRead = Math.max(t.cacheRead, curCR);
+        t.cacheWrite = Math.max(t.cacheWrite, curCW);
         t.total = t.input + t.output + t.cacheRead + t.cacheWrite;
         if (u.cost?.total) {
-          state.sessionStats.cost = (state.sessionStats.cost || 0) + u.cost.total;
+          state.sessionStats.cost = Math.max(state.sessionStats.cost || 0, u.cost.total);
         }
       }
 
       {
-        // message_end.usage is per-call (mirrors pi's AssistantMessage.usage).
-        // Prompt size = input + cacheRead + cacheWrite. Output is the reply.
-        const uTotal = (u as any).totalTokens as number | undefined;
-        const contextTokens = typeof uTotal === "number" && uTotal > 0
-          ? uTotal
-          : (u.input || 0) + (u.cacheRead || 0) + (u.cacheWrite || 0);
+        // Context %: prefer perCallUsage.totalTokens (matches pi's own
+        // calculateContextTokens exactly), fall back to the field sum.
+        // Never delta-compute from `usage` — it's a session aggregate.
         const contextWindow = resolveContextWindow();
+        if (contextWindow > 0) {
+          state.sessionStats.contextWindow = contextWindow;
+        }
+        let contextTokens = 0;
+        if (perCall && typeof perCall.totalTokens === "number" && perCall.totalTokens > 0) {
+          contextTokens = perCall.totalTokens;
+        } else if (perCall) {
+          contextTokens = (perCall.input || 0) + (perCall.output || 0) + (perCall.cacheRead || 0) + (perCall.cacheWrite || 0);
+        }
+        console.debug(`[gsd:context] ctx=${contextTokens}/${contextWindow} perCall=${perCall ? JSON.stringify(perCall) : "n/a"}`);
         if (contextWindow > 0 && contextTokens > 0) {
           state.sessionStats.contextTokens = contextTokens;
-          state.sessionStats.contextWindow = contextWindow;
           state.sessionStats.contextPercent = (contextTokens / contextWindow) * 100;
-          console.debug(`[gsd:context] message_end context%: ${(contextTokens / contextWindow * 100).toFixed(1)}% (tokens=${contextTokens}, window=${contextWindow})`);
         }
       }
       updateHeaderUI();

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -236,7 +236,17 @@ export function init(deps: MessageHandlerDeps): void {
 
   resetDerivedSessionTracking();
 
+  // Remove any previously-registered listener before adding a fresh one so
+  // that re-initialisation (e.g. in tests) does not accumulate duplicates.
+  window.removeEventListener("message", handleMessage);
   window.addEventListener("message", handleMessage);
+}
+
+/** Remove the window message listener registered by {@link init}. Call this in
+ *  test afterEach hooks (or wherever teardown is needed) to prevent listener
+ *  accumulation across test runs. */
+export function cleanup(): void {
+  window.removeEventListener("message", handleMessage);
 }
 
 // ============================================================

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -883,20 +883,30 @@ function handleMessage(event: MessageEvent): void {
               renderer.updateToolSegmentElement(toolId);
             }
           }
-          // If the existing batch is stale (no running members and disjoint
-          // from the new wave) finalize it before starting the new batch,
-          // so sequential waves don't get merged.
+          // If the existing batch is disjoint from the new wave, split — this
+          // message_end is a definitive wave boundary from the provider side.
+          // A disjoint tool-id set means the model has moved on to a new wave;
+          // merging them would collapse sequential responses into one giant
+          // batch (the "162 tools in one block" production bug). The prior
+          // batch may still have running members (long-running Agent/Task
+          // tools) — seal it so those keep their spinner inside the closed
+          // batch and finalize on their own tool_execution_end.
           if (activeBatchToolIds) {
             const newIdSet = new Set(postSealedToolIds);
             const overlaps = [...activeBatchToolIds].some(id => newIdSet.has(id));
-            const hasRunningMember = [...activeBatchToolIds].some(id => {
-              const t = state.currentTurn!.toolCalls.get(id);
-              return t?.isRunning;
-            });
-            if (!overlaps && !hasRunningMember) {
+            if (!overlaps) {
+              const hasRunningMember = [...activeBatchToolIds].some(id => {
+                const t = state.currentTurn!.toolCalls.get(id);
+                return t?.isRunning;
+              });
               if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
-              console.debug(`[gsd:parallel] message_end: stale batch (${activeBatchToolIds.size} done, disjoint) — finalizing before new wave`);
-              renderer.finalizeParallelBatch(lastMessageUsage);
+              if (hasRunningMember) {
+                console.debug(`[gsd:parallel] message_end: disjoint new wave (${activeBatchToolIds.size} prior, some running) — sealing before new wave`);
+                renderer.sealActiveBatch();
+              } else {
+                console.debug(`[gsd:parallel] message_end: disjoint new wave (${activeBatchToolIds.size} done) — finalizing before new wave`);
+                renderer.finalizeParallelBatch(lastMessageUsage);
+              }
               activeBatchToolIds = null;
             }
           }

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -818,14 +818,53 @@ function handleMessage(event: MessageEvent): void {
       const endMsg = endData.message;
       // Extract definitive parallel tool IDs from message content blocks.
       // All tool_use blocks in a single API message are parallel by definition.
+      // Include `serverToolUse` (and SDK-native `server_tool_use`) blocks —
+      // these represent server-executed tools such as the Agent/Task subagent
+      // dispatch or web_search. They co-occur with regular tool_use blocks in
+      // the same message and MUST participate in the parallel-batch set,
+      // otherwise the visible tool count undercounts reality.
       if (endMsg?.content && state.currentTurn) {
         const blocks = Array.isArray(endMsg.content) ? endMsg.content : [];
         console.debug(`[gsd:parallel] message_end: ${blocks.length} content blocks, types=[${blocks.map((b: any) => b.type).join(",")}]`);
+        const toolBlockTypes = new Set([
+          "tool_use",
+          "toolCall",
+          "tool-use",
+          "serverToolUse",
+          "server_tool_use",
+        ]);
         const toolIds = blocks
-          .filter((b: any) => b.type === "tool_use" || b.type === "toolCall" || b.type === "tool-use")
+          .filter((b: any) => toolBlockTypes.has(b.type))
           .map((b: any) => b.id)
           .filter(Boolean) as string[];
         console.debug(`[gsd:parallel] message_end: ${toolIds.length} tool IDs found`);
+
+        // Server-side tool blocks (Agent/Task, web_search, etc.) complete on
+        // the provider side and never emit tool_execution_start/end locally.
+        // Synthesize a tool segment here so the UI shows them as part of the
+        // batch, otherwise a 5-Bash + 5-Agent wave renders as "5 tools" not 10.
+        for (const block of blocks) {
+          const bType = (block as any).type;
+          if (bType !== "serverToolUse" && bType !== "server_tool_use") continue;
+          const bId = (block as any).id as string | undefined;
+          if (!bId || state.currentTurn.toolCalls.has(bId)) continue;
+          const input = (block as any).input ?? (block as any).arguments ?? {};
+          const tc: ToolCallState = {
+            id: bId,
+            name: String((block as any).name ?? "server_tool"),
+            args: typeof input === "object" && input !== null ? (input as Record<string, unknown>) : {},
+            resultText: "",
+            isError: false,
+            isRunning: false,
+            startTime: Date.now(),
+            endTime: Date.now(),
+            isParallel: toolIds.length >= 2,
+          };
+          state.currentTurn.toolCalls.set(bId, tc);
+          const segIdx = state.currentTurn.segments.length;
+          state.currentTurn.segments.push({ type: "tool", toolCallId: bId });
+          renderer.appendToolSegmentElement(tc, segIdx);
+        }
         // Filter out tools that already belong to a sealed batch (prior wave).
         // A single API message may contain multiple waves separated by text/thinking
         // blocks — those thought-cycle boundaries sealed the earlier waves, so we
@@ -890,38 +929,70 @@ function handleMessage(event: MessageEvent): void {
           const u = (endMsg as any).usage as { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; cost?: { total?: number } };
           lastMessageUsage = u;
 
+          // pi's claude-code-cli adapter exposes a `perCallUsage` field on the
+          // assistant message carrying the *last* API call's usage snapshot
+          // (input, output, cacheRead, cacheWrite, totalTokens). That is the
+          // authoritative signal for context window pressure — `usage` is a
+          // session-wide running aggregate and is NOT per-call.
+          // See: gsd-pi partial-builder.js ZERO_USAGE + captureMessageStartUsage.
+          const perCall = (endMsg as any).perCallUsage as
+            | { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; totalTokens?: number }
+            | undefined;
+
           if (!hasCostUpdateSource) {
-            // Only accumulate session totals from message_end when cost_update
-            // events are absent. cost_update is the authoritative source in v2
-            // protocol; using both would double-count tokens.
+            // cost_update is the authoritative session-total source in v2.
+            // When absent (older providers), mirror pi's session-stat behaviour:
+            // `usage` here is already cumulative across the session for
+            // assistant messages, so assign directly rather than accumulating.
+            const curIn = u.input || 0;
+            const curOut = u.output || 0;
+            const curCR = u.cacheRead || 0;
+            const curCW = u.cacheWrite || 0;
             if (!state.sessionStats.tokens) {
               state.sessionStats.tokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
             }
             const t = state.sessionStats.tokens;
-            t.input += u.input || 0;
-            t.output += u.output || 0;
-            t.cacheRead += u.cacheRead || 0;
-            t.cacheWrite += u.cacheWrite || 0;
+            // Monotonic max guard — pi's session stats are non-decreasing, so
+            // any apparent regression is a provider/stream reset, not a real
+            // drop. Taking max prevents the header from visibly dipping.
+            t.input = Math.max(t.input, curIn);
+            t.output = Math.max(t.output, curOut);
+            t.cacheRead = Math.max(t.cacheRead, curCR);
+            t.cacheWrite = Math.max(t.cacheWrite, curCW);
             t.total = t.input + t.output + t.cacheRead + t.cacheWrite;
             if (u.cost?.total) {
-              state.sessionStats.cost = (state.sessionStats.cost || 0) + u.cost.total;
+              state.sessionStats.cost = Math.max(state.sessionStats.cost || 0, u.cost.total);
             }
           }
 
-          // Context %: message_end.usage is per-call, mirroring pi's AssistantMessage.usage.
-          // Prompt size = input + cacheRead + cacheWrite (output is the reply, not the prompt).
-          // Matches pi's calculateContextTokens() when totalTokens is unset.
+          // Context %: use perCallUsage.totalTokens when provided by pi
+          // (preferred — exact match of pi's own calculateContextTokens()).
+          // Fall back to perCall input+output+cacheRead+cacheWrite. Never
+          // delta-compute from `usage` — it's a session-cumulative aggregate,
+          // not a turn-local snapshot, so deltas across message_end events
+          // yield nonsense context sizes.
           {
-            const uTotal = (u as any).totalTokens as number | undefined;
-            const contextTokens = typeof uTotal === "number" && uTotal > 0
-              ? uTotal
-              : (u.input || 0) + (u.cacheRead || 0) + (u.cacheWrite || 0);
             const contextWindow = resolveContextWindow();
+            if (contextWindow > 0) {
+              state.sessionStats.contextWindow = contextWindow;
+            }
+            let contextTokens = 0;
+            let source = "none";
+            if (perCall && typeof perCall.totalTokens === "number" && perCall.totalTokens > 0) {
+              contextTokens = perCall.totalTokens;
+              source = "perCall.totalTokens";
+            } else if (perCall) {
+              const pIn = perCall.input || 0;
+              const pOut = perCall.output || 0;
+              const pCR = perCall.cacheRead || 0;
+              const pCW = perCall.cacheWrite || 0;
+              contextTokens = pIn + pOut + pCR + pCW;
+              if (contextTokens > 0) source = "perCall.sum";
+            }
+            console.debug(`[gsd:context] ctx=${contextTokens}/${contextWindow} src=${source} perCall=${perCall ? JSON.stringify(perCall) : "n/a"} usage=${JSON.stringify({ input: u.input, output: u.output, cacheRead: u.cacheRead, cacheWrite: u.cacheWrite })}`);
             if (contextWindow > 0 && contextTokens > 0) {
               state.sessionStats.contextTokens = contextTokens;
-              state.sessionStats.contextWindow = contextWindow;
               state.sessionStats.contextPercent = (contextTokens / contextWindow) * 100;
-              console.debug(`[gsd:context] message_end context%: ${(contextTokens / contextWindow * 100).toFixed(1)}% (tokens=${contextTokens}, window=${contextWindow})`);
             }
           }
           updateHeaderUI();

--- a/src/webview/render/batches.ts
+++ b/src/webview/render/batches.ts
@@ -17,6 +17,7 @@ import {
   getMessagesContainer,
   resetStreamingInternals,
   detectStaleEcho,
+  resolveContainerLevelAnchor,
 } from "./streaming";
 
 let activeBatchElement: HTMLElement | null = null;
@@ -148,7 +149,12 @@ export function createParallelBatch(toolIds: string[]): void {
     }
   }
 
-  if (!firstEl) { cte.appendChild(batch); } else { firstEl.parentNode!.insertBefore(batch, firstEl); }
+  if (!firstEl) {
+    cte.appendChild(batch);
+  } else {
+    const anchor = resolveContainerLevelAnchor(cte, firstEl);
+    anchor.parentNode!.insertBefore(batch, anchor);
+  }
 
   for (const toolId of toolIds) {
     const el = cte.querySelector<HTMLElement>(`.gsd-tool-segment[data-tool-id="${toolId}"]`);
@@ -215,10 +221,41 @@ export function updateParallelBatchStatus(): void {
 
   const total = running + done + errored;
   const label = activeBatchElement.querySelector(".gsd-parallel-batch-label");
-  if (label && running > 0) {
-    label.textContent = `${total} tools — ${done + errored} done, ${running} running`;
+  if (running > 0) {
+    if (label) label.textContent = `${total} tools — ${done + errored} done, ${running} running`;
+  } else if (total > 0) {
+    // Last tool in the batch just finished. Swap the spinner for a check and
+    // restate the label now — waiting for the 800ms finalize timer leaves the
+    // container visually "running" while the model is already emitting more
+    // content. Keep activeBatchElement pointed at this node so the timer can
+    // still append footer pills (and a follow-up wave can reopen it).
+    applyIdleHeader(activeBatchElement, total, errored);
   }
   updateBatchElapsed();
+}
+
+// Visually transition a still-active batch to its "done" header state without
+// detaching it or writing the final duration. finalizeBatchElement will later
+// overwrite the label with the precise duration and add footer pills; this is
+// the intermediate "everything finished, waiting on finalize" state.
+function applyIdleHeader(element: HTMLElement, total: number, errored: number): void {
+  element.classList.remove("running");
+  element.classList.add("done");
+  const spinner = element.querySelector(".gsd-parallel-batch-header .gsd-tool-spinner");
+  if (spinner) {
+    const icon = document.createElement("span");
+    icon.className = errored > 0 ? "gsd-tool-icon error" : "gsd-tool-icon success";
+    icon.textContent = errored > 0 ? "✗" : "✓";
+    spinner.replaceWith(icon);
+  }
+  const label = element.querySelector(".gsd-parallel-batch-label");
+  if (label) {
+    label.textContent = errored > 0
+      ? `${total} tools completed (${errored} failed)`
+      : `${total} tools completed`;
+  }
+  const elapsed = element.querySelector(".gsd-parallel-batch-elapsed");
+  if (elapsed) elapsed.textContent = "";
 }
 
 export function finalizeParallelBatch(turnUsage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; cost?: { total?: number } } | null): void {
@@ -450,8 +487,12 @@ export function syncBatchState(trackedIds: Set<string>): void {
           firstEl = el;
         }
       }
-      if (firstEl && firstEl.parentNode) { firstEl.parentNode.insertBefore(batch, firstEl); }
-      else { cte.appendChild(batch); }
+      if (firstEl) {
+        const anchor = resolveContainerLevelAnchor(cte, firstEl);
+        anchor.parentNode!.insertBefore(batch, anchor);
+      } else {
+        cte.appendChild(batch);
+      }
 
       activeBatchElement = batch;
       batch.dataset.startTime = String(Date.now());

--- a/src/webview/render/streaming.ts
+++ b/src/webview/render/streaming.ts
@@ -474,9 +474,22 @@ function insertSegmentElement(container: HTMLElement, segIdx: number, el: HTMLEl
   el.dataset.segIdx = String(segIdx);
   let inserted = false;
   for (const [idx, existingEl] of segmentElements) {
-    if (idx > segIdx) { container.insertBefore(el, existingEl); inserted = true; break; }
+    if (idx > segIdx) {
+      const anchor = resolveContainerLevelAnchor(container, existingEl);
+      anchor.parentNode!.insertBefore(el, anchor);
+      inserted = true;
+      break;
+    }
   }
   if (!inserted) container.appendChild(el);
+}
+
+export function resolveContainerLevelAnchor(container: HTMLElement, anchor: HTMLElement): HTMLElement {
+  let cur: HTMLElement | null = anchor;
+  while (cur && cur.parentNode !== container) {
+    cur = cur.parentElement;
+  }
+  return cur || anchor;
 }
 
 export function initStreaming(deps: { messagesContainer: HTMLElement; welcomeScreen: HTMLElement }): void {

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -910,13 +910,43 @@ export function updateParallelBatchStatus(): void {
 
   const total = running + done + errored;
   const label = activeBatchElement.querySelector(".gsd-parallel-batch-label");
-  if (label) {
-    if (running > 0) {
-      label.textContent = `${total} tools — ${done + errored} done, ${running} running`;
-    }
+  if (running > 0) {
+    if (label) label.textContent = `${total} tools — ${done + errored} done, ${running} running`;
+  } else if (total > 0) {
+    // Last tool in the batch just finished. Swap the spinner for a check and
+    // restate the label now — waiting for the 800ms finalize timer leaves the
+    // container visually "running" while the model is already emitting more
+    // content. Keep activeBatchElement pointed at this node so the timer can
+    // still append footer pills (and a follow-up wave can reopen it).
+    applyIdleHeader(activeBatchElement, total, errored);
   }
 
   updateBatchElapsed();
+}
+
+// Transition a still-active batch to its "done" header state without detaching
+// it or writing a final duration. finalizeBatchElement will later overwrite
+// the label with the precise duration and add footer pills; this is the
+// intermediate "all finished, waiting on finalize" state so the user doesn't
+// see a spinner for a batch whose tools have already completed.
+function applyIdleHeader(element: HTMLElement, total: number, errored: number): void {
+  element.classList.remove("running");
+  element.classList.add("done");
+  const spinner = element.querySelector(".gsd-parallel-batch-header .gsd-tool-spinner");
+  if (spinner) {
+    const icon = document.createElement("span");
+    icon.className = errored > 0 ? "gsd-tool-icon error" : "gsd-tool-icon success";
+    icon.textContent = errored > 0 ? "✗" : "✓";
+    spinner.replaceWith(icon);
+  }
+  const label = element.querySelector(".gsd-parallel-batch-label");
+  if (label) {
+    label.textContent = errored > 0
+      ? `${total} tools completed (${errored} failed)`
+      : `${total} tools completed`;
+  }
+  const elapsed = element.querySelector(".gsd-parallel-batch-elapsed");
+  if (elapsed) elapsed.textContent = "";
 }
 
 /**

--- a/src/webview/styles/entries.css
+++ b/src/webview/styles/entries.css
@@ -71,7 +71,26 @@
 /* ---- Assistant turn ---- */
 
 .gsd-entry-assistant {
-  /* full width */
+  position: relative;
+  padding-left: 12px;
+}
+
+.gsd-entry-assistant::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  background: color-mix(in srgb, var(--gsd-color-accent) 35%, transparent);
+  border-radius: 1px;
+  transition: background 0.2s ease;
+  pointer-events: none;
+}
+
+.gsd-entry-assistant:hover::before,
+.gsd-entry-assistant.streaming::before {
+  background: var(--gsd-color-accent);
 }
 
 .gsd-entry-assistant + .gsd-entry-assistant {

--- a/src/webview/ui-updates.ts
+++ b/src/webview/ui-updates.ts
@@ -134,6 +134,13 @@ export function updateHeaderUI(): void {
     contextBadge.classList.remove("warn", "crit");
     if (pct > 90) contextBadge.classList.add("crit");
     else if (pct > 70) contextBadge.classList.add("warn");
+    const spent = stats.tokens
+      ? (stats.tokens.input || 0) + (stats.tokens.output || 0) + (stats.tokens.cacheRead || 0) + (stats.tokens.cacheWrite || 0)
+      : 0;
+    contextBadge.title =
+      "Size of the NEXT prompt relative to the context window.\n" +
+      "This is a level, not a total — it can drop after compaction.\n" +
+      (spent > 0 ? `Cumulative session spend: ${formatTokens(spent)} tokens (see footer 'spent:').` : "");
   } else {
     contextBadge.classList.add('gsd-hidden');
   }
@@ -184,6 +191,8 @@ export function updateFooterUI(): void {
     if (tokens.input) tokenParts.push(`in:${formatTokens(tokens.input)}`);
     if (tokens.output) tokenParts.push(`out:${formatTokens(tokens.output)}`);
     if (tokens.cacheRead) tokenParts.push(`cache:${formatTokens(tokens.cacheRead)}`);
+    const totalSpent = (tokens.input || 0) + (tokens.output || 0) + (tokens.cacheRead || 0) + (tokens.cacheWrite || 0);
+    if (totalSpent > 0) tokenParts.push(`spent:${formatTokens(totalSpent)}`);
     if (tokenParts.length > 0) parts.push(tokenParts.join(" "));
   }
 
@@ -195,6 +204,9 @@ export function updateFooterUI(): void {
   if (ctx) parts.push(ctx);
 
   footerStats.textContent = parts.join(" · ");
+  footerStats.title =
+    "spent = cumulative tokens this session (grows monotonically)\n" +
+    "%/window = size of the NEXT prompt relative to the context window — can shrink after compaction";
 
   let right = "";
   if (state.model) {


### PR DESCRIPTION
## Summary
- **Parallel batch splitting (production bug)**: when gsd-pi's external SDK adapter (claude-code mode) emits sequential assistant messages in one turn without an intermediate `message_start`, the webview merged every wave's tools into one giant batch — producing the "162 tools completed in 1118s" rendering. A disjoint tool-id set on `message_end` is now treated as a definitive wave boundary and splits the batch even when long-running Agent/Task tools remain in flight.
- **Context % badge accuracy**: the header/footer now read `perCallUsage` (pi's per-API-call snapshot) instead of deriving from the session-cumulative `usage` aggregate, fixing the runaway-context readout.
- **Agent/serverToolUse blocks in parallel batches**: `message_end` content blocks typed `serverToolUse`/`server_tool_use` (Agent, Task, web_search) now participate in the parallel batch set, so a "5 Bash + 5 Agent" wave renders as 10 tools instead of 5.

## Test plan
- [x] `npx vitest run` — 1302/1302 pass (9 new E2E parallel-batch tests, including the failing production-bug repro now green)
- [x] VSIX 0.3.38 builds clean
- [ ] Manual smoke test in claude-code external SDK mode with a long multi-wave turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognise and display server-executed tool blocks alongside regular tool uses
  * Show session "spent" token totals in header/footer tooltips

* **Bug Fixes**
  * Prevent token regressions by using monotonic token aggregation
  * Refine context-percentage calculations with robust per-call usage fallback
  * Improve parallel-tool batch grouping and DOM insertion and idle-header transitions

* **Style**
  * Add left accent bar and hover/streaming styling for assistant messages

* **Tests**
  * Add extensive unit and e2e tests covering token handling and parallel-batch rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->