### PR TITLE
fix: streaming-granular batch reconciliation

### DIFF
--- a/dist/meta-webview.json
+++ b/dist/meta-webview.json
@@ -343,7 +343,7 @@
       "format": "esm"
     },
     "src/webview/renderer.ts": {
-      "bytes": 87290,
+      "bytes": 88016,
       "imports": [
         {
           "path": "src/webview/state.ts",
@@ -514,7 +514,7 @@
       "format": "esm"
     },
     "src/webview/message-handler.ts": {
-      "bytes": 87777,
+      "bytes": 93665,
       "imports": [
         {
           "path": "src/webview/helpers.ts",
@@ -812,7 +812,7 @@
       "imports": [],
       "exports": [],
       "inputs": {},
-      "bytes": 943040
+      "bytes": 953553
     },
     "dist/webview/index.js": {
       "imports": [],
@@ -875,10 +875,10 @@
           "bytesInOutput": 1148
         },
         "node_modules/marked/lib/marked.esm.js": {
-          "bytesInOutput": 38670
+          "bytesInOutput": 38668
         },
         "node_modules/dompurify/dist/purify.es.mjs": {
-          "bytesInOutput": 22757
+          "bytesInOutput": 22751
         },
         "src/webview/dispose.ts": {
           "bytesInOutput": 383
@@ -920,10 +920,10 @@
           "bytesInOutput": 232
         },
         "src/webview/renderer.ts": {
-          "bytesInOutput": 32839
+          "bytesInOutput": 33008
         },
         "src/webview/dashboard.ts": {
-          "bytesInOutput": 10406
+          "bytesInOutput": 10399
         },
         "src/webview/auto-progress.ts": {
           "bytesInOutput": 6497
@@ -938,7 +938,7 @@
           "bytesInOutput": 6809
         },
         "src/webview/message-handler.ts": {
-          "bytesInOutput": 28859
+          "bytesInOutput": 31665
         },
         "src/webview/ui-updates.ts": {
           "bytesInOutput": 7858
@@ -947,7 +947,7 @@
           "bytesInOutput": 19106
         }
       },
-      "bytes": 242171
+      "bytes": 245131
     },
     "dist/webview/index.css.map": {
       "imports": [],

--- a/dist/meta-webview.json
+++ b/dist/meta-webview.json
@@ -343,7 +343,7 @@
       "format": "esm"
     },
     "src/webview/renderer.ts": {
-      "bytes": 83281,
+      "bytes": 87290,
       "imports": [
         {
           "path": "src/webview/state.ts",
@@ -514,7 +514,7 @@
       "format": "esm"
     },
     "src/webview/message-handler.ts": {
-      "bytes": 84494,
+      "bytes": 87777,
       "imports": [
         {
           "path": "src/webview/helpers.ts",
@@ -812,7 +812,7 @@
       "imports": [],
       "exports": [],
       "inputs": {},
-      "bytes": 931273
+      "bytes": 943040
     },
     "dist/webview/index.js": {
       "imports": [],
@@ -878,7 +878,7 @@
           "bytesInOutput": 38670
         },
         "node_modules/dompurify/dist/purify.es.mjs": {
-          "bytesInOutput": 22739
+          "bytesInOutput": 22757
         },
         "src/webview/dispose.ts": {
           "bytesInOutput": 383
@@ -917,10 +917,10 @@
           "bytesInOutput": 3598
         },
         "src/webview/render/streaming.ts": {
-          "bytesInOutput": 151
+          "bytesInOutput": 232
         },
         "src/webview/renderer.ts": {
-          "bytesInOutput": 31705
+          "bytesInOutput": 32839
         },
         "src/webview/dashboard.ts": {
           "bytesInOutput": 10406
@@ -938,7 +938,7 @@
           "bytesInOutput": 6809
         },
         "src/webview/message-handler.ts": {
-          "bytesInOutput": 28007
+          "bytesInOutput": 28859
         },
         "src/webview/ui-updates.ts": {
           "bytesInOutput": 7858
@@ -947,7 +947,7 @@
           "bytesInOutput": 19106
         }
       },
-      "bytes": 240086
+      "bytes": 242171
     },
     "dist/webview/index.css.map": {
       "imports": [],

--- a/src/webview/__tests__/message-handler.test.ts
+++ b/src/webview/__tests__/message-handler.test.ts
@@ -26,7 +26,19 @@ vi.mock("../renderer", () => ({
   sealActiveBatch: vi.fn(() => null),
   tickSealedBatches: vi.fn(),
   isInSealedBatch: vi.fn(() => false),
+  isInCompletedBatch: vi.fn(() => false),
   finalizeAllSealedBatches: vi.fn(),
+  clearFinalizedBatch: vi.fn(),
+  disbandActiveBatch: vi.fn(),
+  unsealBatchesOverlapping: vi.fn(),
+  disbandOrphanedBatches: vi.fn(),
+  getSealedBatchCount: vi.fn(() => 0),
+  reopenParallelBatch: vi.fn(),
+  appendServerToolSegment: vi.fn(),
+  completeServerToolSegment: vi.fn(),
+  reattachTurnElement: vi.fn(),
+  patchToolBlock: vi.fn(),
+  init: vi.fn(),
 }));
 
 vi.mock("../session-history", () => ({
@@ -533,6 +545,53 @@ describe("message-handler", () => {
       expect(state.currentTurn!.toolCalls.get("t2")!.isParallel).toBe(true);
       // First tool should now be marked parallel too
       expect(state.currentTurn!.toolCalls.get("t1")!.isParallel).toBe(true);
+    });
+
+    it("does not re-mark tool as running when toolcall_end already completed it", () => {
+      sendMessage({ type: "agent_start" });
+
+      // Streaming creates the tool via toolcall_start
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          partial: {
+            content: [{ type: "toolCall", id: "tc1", name: "Read" }],
+          },
+          contentIndex: 0,
+        },
+      });
+      const tc = state.currentTurn!.toolCalls.get("tc1")!;
+      expect(tc.isRunning).toBe(true);
+
+      // toolcall_end with externalResult completes the tool
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_end",
+          toolCall: {
+            id: "tc1",
+            name: "Read",
+            arguments: { path: "foo.ts" },
+            externalResult: {
+              content: [{ text: "file contents" }],
+            },
+          },
+        },
+      });
+      expect(tc.isRunning).toBe(false);
+      expect(tc.endTime).toBeDefined();
+      expect(tc.resultText).toBe("file contents");
+
+      // tool_execution_start arrives late — should NOT re-mark as running
+      sendMessage({
+        type: "tool_execution_start",
+        toolCallId: "tc1",
+        toolName: "Read",
+        args: { path: "foo.ts" },
+      });
+      expect(tc.isRunning).toBe(false);
+      expect(tc.endTime).toBeDefined();
     });
   });
 

--- a/src/webview/__tests__/message-handler.test.ts
+++ b/src/webview/__tests__/message-handler.test.ts
@@ -33,6 +33,8 @@ vi.mock("../renderer", () => ({
   unsealBatchesOverlapping: vi.fn(),
   disbandOrphanedBatches: vi.fn(),
   getSealedBatchCount: vi.fn(() => 0),
+  getSealedBatchWaves: vi.fn(() => []),
+  getCurrentTurnElement: vi.fn(() => null),
   reopenParallelBatch: vi.fn(),
   appendServerToolSegment: vi.fn(),
   completeServerToolSegment: vi.fn(),

--- a/src/webview/__tests__/parallel-batch-e2e.test.ts
+++ b/src/webview/__tests__/parallel-batch-e2e.test.ts
@@ -656,13 +656,11 @@ describe("parallel batch rendering (E2E, real renderer)", () => {
     expect(r2).toEqual(["r2-t1", "r2-t2"]);
   });
 
-  it("PRODUCTION BUG: text_delta between toolcall_start events in streaming must NOT split the batch", () => {
-    // Reproduces the real-world bug: Claude streams toolcall_start events with
-    // brief text_delta fragments between them (streaming cadence artifact, not
-    // real narration). Before the fix, each text_delta sealed the batch,
-    // splitting 4 parallel tools into 2-tool sealed batches. After the fix,
-    // text_delta during messageInFlight is ignored and message_end organizes
-    // the batch correctly.
+  it("text_delta between toolcall_start events in streaming preserves batch boundaries", () => {
+    // Claude streams toolcall_start events with text_delta narration between
+    // tool groups. The streaming-established batch boundaries (sealed by
+    // text_delta) are preserved over the API's flattened single-wave view,
+    // since the text_delta represents real narration between tool batches.
     sendMessage({ type: "agent_start" });
     sendMessage({ type: "message_start" });
 
@@ -716,17 +714,17 @@ describe("parallel batch rendering (E2E, real renderer)", () => {
       });
     }
 
-    // All 4 tools must be in ONE batch, not split into 2-tool sealed batches
+    // Streaming text_delta between tool groups creates sealed batches.
+    // The streaming-granular structure is preserved over the API's flattened
+    // single-wave view, since the text_delta narration is a real batch boundary.
     const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
-    expect(batches.length).toBe(1);
-    const segments = batches[0].querySelectorAll(
-      ".gsd-parallel-batch-content .gsd-tool-segment",
-    );
-    expect(segments.length).toBe(4);
-    const ids = Array.from(segments)
-      .map((el) => (el as HTMLElement).dataset.toolId!)
-      .sort();
-    expect(ids).toEqual(["s1", "s2", "s3", "s4"]);
+    expect(batches.length).toBe(2);
+    const batch1Ids = Array.from(batches[0].querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+      .map(el => el.dataset.toolId!).sort();
+    const batch2Ids = Array.from(batches[1].querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+      .map(el => el.dataset.toolId!).sort();
+    expect(batch1Ids).toEqual(["s1", "s2"]);
+    expect(batch2Ids).toEqual(["s3", "s4"]);
 
     // No orphaned tools outside batches
     const looseSegments = messagesContainer.querySelectorAll(

--- a/src/webview/__tests__/parallel-batch-e2e.test.ts
+++ b/src/webview/__tests__/parallel-batch-e2e.test.ts
@@ -330,9 +330,19 @@ describe("parallel batch rendering (E2E, real renderer)", () => {
       sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
     }
 
-    // Single message_end with ALL 5 tools as content blocks — but post-seal
-    // filtering should have already split them into two batches via narration.
-    sendMessage(msgEndWithTools([...wave1, ...wave2]));
+    // message_end with text block separating the two waves — narration is part
+    // of the authoritative content structure, so wave splitting sees 2 waves.
+    sendMessage({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          ...wave1.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+          { type: "text", text: "Now checking the next set." },
+          ...wave2.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+        ],
+      },
+    });
 
     const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
     expect(batches.length).toBe(2);
@@ -644,5 +654,1004 @@ describe("parallel batch rendering (E2E, real renderer)", () => {
     const r2 = batchIds.find((ids) => ids.some((id) => id.startsWith("r2-")))!;
     expect(r1).toEqual(["r1-t1", "r1-t2"]);
     expect(r2).toEqual(["r2-t1", "r2-t2"]);
+  });
+
+  it("PRODUCTION BUG: text_delta between toolcall_start events in streaming must NOT split the batch", () => {
+    // Reproduces the real-world bug: Claude streams toolcall_start events with
+    // brief text_delta fragments between them (streaming cadence artifact, not
+    // real narration). Before the fix, each text_delta sealed the batch,
+    // splitting 4 parallel tools into 2-tool sealed batches. After the fix,
+    // text_delta during messageInFlight is ignored and message_end organizes
+    // the batch correctly.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    // Streaming: Grep A, Grep B, then text_delta, then Bash C, Bash D
+    const allTools = [
+      { id: "s1", name: "Grep" },
+      { id: "s2", name: "Grep" },
+      { id: "s3", name: "Bash" },
+      { id: "s4", name: "Bash" },
+    ];
+    // Wave 1 pair
+    for (const t of allTools.slice(0, 2)) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    // Text fragment between tool groups (streaming artifact)
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Running searches..." },
+    });
+    // Wave 2 pair
+    for (const t of allTools.slice(2)) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+
+    // message_end with all 4 tools — authoritative parallel set
+    sendMessage(msgEndWithTools(allTools));
+
+    // tool_execution_start for all 4
+    for (const t of allTools) {
+      sendMessage({
+        type: "tool_execution_start",
+        toolCallId: t.id,
+        toolName: t.name,
+        args: { command: `test-${t.id}` },
+      });
+    }
+
+    // All 4 tools must be in ONE batch, not split into 2-tool sealed batches
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(1);
+    const segments = batches[0].querySelectorAll(
+      ".gsd-parallel-batch-content .gsd-tool-segment",
+    );
+    expect(segments.length).toBe(4);
+    const ids = Array.from(segments)
+      .map((el) => (el as HTMLElement).dataset.toolId!)
+      .sort();
+    expect(ids).toEqual(["s1", "s2", "s3", "s4"]);
+
+    // No orphaned tools outside batches
+    const looseSegments = messagesContainer.querySelectorAll(
+      ".gsd-assistant-turn > .gsd-tool-segment",
+    );
+    expect(looseSegments.length).toBe(0);
+  });
+
+  it("PRODUCTION BUG: 3 tool waves with text blocks in single message_end must split into 3 batches", () => {
+    // Claude Code sends all tool waves in one API message when the model emits
+    // text between parallel tool groups within a single response. The message_end
+    // content looks like: [tool×5, text, tool×5, text, tool×4]. Each contiguous
+    // run of tool blocks must be a separate batch; text blocks are wave boundaries.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    const wave1 = [
+      { id: "m1", name: "Read" },
+      { id: "m2", name: "Read" },
+      { id: "m3", name: "Read" },
+    ];
+    const wave2 = [
+      { id: "m4", name: "Read" },
+      { id: "m5", name: "Read" },
+      { id: "m6", name: "Read" },
+    ];
+    const wave3 = [
+      { id: "m7", name: "Read" },
+      { id: "m8", name: "Read" },
+    ];
+
+    // Streaming: all toolcall_start events arrive first
+    for (const t of [...wave1, ...wave2, ...wave3]) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+
+    // Single message_end with text blocks separating tool waves
+    sendMessage({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Wave 1: 3 parallel reads." },
+          ...wave1.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+          { type: "text", text: "Wave 1 done. Wave 2: 3 more reads." },
+          ...wave2.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+          { type: "text", text: "Wave 2 done. Wave 3: 2 reads." },
+          ...wave3.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+        ],
+      },
+    });
+
+    // tool_execution_start for all
+    for (const t of [...wave1, ...wave2, ...wave3]) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(3);
+
+    const batchIds = Array.from(batches).map((b) =>
+      Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+        .map((el) => el.dataset.toolId!)
+        .sort(),
+    );
+    expect(batchIds).toContainEqual(["m1", "m2", "m3"]);
+    expect(batchIds).toContainEqual(["m4", "m5", "m6"]);
+    expect(batchIds).toContainEqual(["m7", "m8"]);
+  });
+
+  it("REGRESSION: 3 waves in single message_end with text separators must survive agent_end", () => {
+    // Same as the "3 tool waves with text blocks in single message_end" test
+    // but extended through agent_end to catch merging during turn finalization.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    const wave1 = [
+      { id: "x1", name: "Read" },
+      { id: "x2", name: "Glob" },
+    ];
+    const wave2 = [
+      { id: "x3", name: "Bash" },
+      { id: "x4", name: "Bash" },
+    ];
+    const wave3 = [
+      { id: "x5", name: "Grep" },
+      { id: "x6", name: "Glob" },
+    ];
+
+    // Streaming: all toolcall_start events
+    for (const t of [...wave1, ...wave2, ...wave3]) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+
+    // Text deltas between waves (narration)
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 1 done." },
+    });
+
+    // Single message_end with text blocks separating tool waves
+    sendMessage({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Wave 1: Read + Glob" },
+          ...wave1.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+          { type: "text", text: "Wave 2: Bash + Bash" },
+          ...wave2.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+          { type: "text", text: "Wave 3: Grep + Glob" },
+          ...wave3.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+        ],
+      },
+    });
+
+    // tool_execution_start + end for all
+    for (const t of [...wave1, ...wave2, ...wave3]) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of [...wave1, ...wave2, ...wave3]) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Before agent_end: 3 batches
+    let batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(3);
+
+    // agent_end
+    sendMessage({ type: "agent_end" });
+
+    // After agent_end: still 3 batches
+    batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(3);
+
+    const batchIds = Array.from(batches).map((b) =>
+      Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+        .map((el) => el.dataset.toolId!)
+        .sort(),
+    );
+    expect(batchIds).toContainEqual(["x1", "x2"]);
+    expect(batchIds).toContainEqual(["x3", "x4"]);
+    expect(batchIds).toContainEqual(["x5", "x6"]);
+  });
+
+  it("REGRESSION: realistic streaming order (text→tools interleaved) must keep 3 batches after agent_end", () => {
+    // Matches real Claude streaming: text_delta before each wave, toolcall_start
+    // events interleaved with text_delta between waves. The text_delta handler
+    // seals the active batch. message_end arrives last with the authoritative
+    // wave structure. agent_end must not merge the batches.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    const wave1 = [
+      { id: "y1", name: "Read" },
+      { id: "y2", name: "Glob" },
+    ];
+    const wave2 = [
+      { id: "y3", name: "Bash" },
+      { id: "y4", name: "Bash" },
+    ];
+    const wave3 = [
+      { id: "y5", name: "Grep" },
+      { id: "y6", name: "Glob" },
+    ];
+
+    // Realistic streaming order: text → tools → text → tools → text → tools
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 1: Read + Glob" },
+    });
+    for (const t of wave1) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    // Text between waves seals wave1 batch
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 2: Bash + Bash" },
+    });
+    for (const t of wave2) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    // Text between waves seals wave2 batch
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 3: Grep + Glob" },
+    });
+    for (const t of wave3) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+
+    // message_end with text blocks separating tool waves
+    sendMessage({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Wave 1: Read + Glob" },
+          ...wave1.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+          { type: "text", text: "Wave 2: Bash + Bash" },
+          ...wave2.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+          { type: "text", text: "Wave 3: Grep + Glob" },
+          ...wave3.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+        ],
+      },
+    });
+
+    // tool_execution_start + end for all
+    for (const t of [...wave1, ...wave2, ...wave3]) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of [...wave1, ...wave2, ...wave3]) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Before agent_end: should have 3 batches
+    let batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(3);
+
+    // agent_end
+    sendMessage({ type: "agent_end" });
+
+    // After: still 3 batches
+    batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(3);
+
+    const batchIds = Array.from(batches).map((b) =>
+      Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+        .map((el) => el.dataset.toolId!)
+        .sort(),
+    );
+    expect(batchIds).toContainEqual(["y1", "y2"]);
+    expect(batchIds).toContainEqual(["y3", "y4"]);
+    expect(batchIds).toContainEqual(["y5", "y6"]);
+  });
+
+  it("REGRESSION: execution events interleaved during streaming — batches must survive agent_end", () => {
+    // In production, tool_execution_start/end can fire DURING streaming of the
+    // same message (Claude Code dispatches tools as soon as it sees the block).
+    // Wave 1 tools might start executing before wave 2 toolcall_start events arrive.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    const wave1 = [
+      { id: "z1", name: "Read" },
+      { id: "z2", name: "Glob" },
+    ];
+    const wave2 = [
+      { id: "z3", name: "Bash" },
+      { id: "z4", name: "Bash" },
+    ];
+    const wave3 = [
+      { id: "z5", name: "Grep" },
+      { id: "z6", name: "Glob" },
+    ];
+
+    // Wave 1 toolcall_start
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 1:" },
+    });
+    for (const t of wave1) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+
+    // Wave 1 tool_execution_start fires during streaming (before text_delta)
+    for (const t of wave1) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    // Wave 1 tool_execution_end fires during streaming
+    for (const t of wave1) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Text between waves seals wave1 batch
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 2:" },
+    });
+    for (const t of wave2) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    for (const t of wave2) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave2) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Text between waves
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 3:" },
+    });
+    for (const t of wave3) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    for (const t of wave3) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave3) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // message_end with authoritative wave structure
+    sendMessage({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Wave 1:" },
+          ...wave1.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+          { type: "text", text: "Wave 2:" },
+          ...wave2.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+          { type: "text", text: "Wave 3:" },
+          ...wave3.map(t => ({ type: "tool_use", id: t.id, name: t.name, input: {} })),
+        ],
+      },
+    });
+
+    // Before agent_end: 3 batches
+    let batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(3);
+
+    // agent_end
+    sendMessage({ type: "agent_end" });
+
+    // After: still 3 batches
+    batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(3);
+
+    const batchIds = Array.from(batches).map((b) =>
+      Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+        .map((el) => el.dataset.toolId!)
+        .sort(),
+    );
+    expect(batchIds).toContainEqual(["z1", "z2"]);
+    expect(batchIds).toContainEqual(["z3", "z4"]);
+    expect(batchIds).toContainEqual(["z5", "z6"]);
+  });
+
+  it("REGRESSION: 3 separate API messages (one per wave) must keep batches after agent_end", () => {
+    // Matches the Claude Code scenario: each wave is a separate API message
+    // with its own message_start/message_end. During streaming, text_delta
+    // and toolcall_start events create proper wave boundaries. On agent_end,
+    // all batches must survive — they must NOT merge into one.
+    sendMessage({ type: "agent_start" });
+
+    // ── Wave 1: 3 tools ──
+    sendMessage({ type: "message_start" });
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 1: 3 reads." },
+    });
+    const wave1 = [
+      { id: "v1", name: "Read" },
+      { id: "v2", name: "Glob" },
+      { id: "v3", name: "Grep" },
+    ];
+    for (const t of wave1) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    sendMessage(msgEndWithTools(wave1));
+    for (const t of wave1) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave1) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // ── Wave 2: 3 tools ──
+    sendMessage({ type: "message_start" });
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 2: 3 bash." },
+    });
+    const wave2 = [
+      { id: "v4", name: "Bash" },
+      { id: "v5", name: "Bash" },
+      { id: "v6", name: "Bash" },
+    ];
+    for (const t of wave2) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    sendMessage(msgEndWithTools(wave2));
+    for (const t of wave2) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave2) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // ── Wave 3: 2 tools ──
+    sendMessage({ type: "message_start" });
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Wave 3: 2 tools." },
+    });
+    const wave3 = [
+      { id: "v7", name: "Grep" },
+      { id: "v8", name: "Glob" },
+    ];
+    for (const t of wave3) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    sendMessage(msgEndWithTools(wave3));
+    for (const t of wave3) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave3) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Verify: 3 separate batches during streaming
+    let batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(3);
+
+    // ── agent_end: finalize the turn ──
+    sendMessage({ type: "agent_end" });
+
+    // After agent_end, the 3 batches must still be 3 separate batches
+    batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(3);
+
+    const batchIds = Array.from(batches).map((b) =>
+      Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+        .map((el) => el.dataset.toolId!)
+        .sort(),
+    );
+    expect(batchIds).toContainEqual(["v1", "v2", "v3"]);
+    expect(batchIds).toContainEqual(["v4", "v5", "v6"]);
+    expect(batchIds).toContainEqual(["v7", "v8"]);
+  });
+
+  it("REGRESSION: orphaned batch from mid-stream finalize must not duplicate tools after agent_end", () => {
+    // Scenario: batch finalized by text_delta (ref cleared), then agent_end.
+    // The orphaned batch element must stay intact — no tool duplication.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    // 3 tools streamed in
+    const tools = [
+      { id: "o1", name: "Bash" },
+      { id: "o2", name: "Bash" },
+      { id: "o3", name: "Read" },
+    ];
+    for (const t of tools) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+
+    // message_end with the 3 tools
+    sendMessage(msgEndWithTools(tools));
+
+    // tool_execution_start + end for all 3
+    for (const t of tools) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of tools) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Text delta after tools complete — this triggers batch finalization + clearFinalizedBatch
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "All done." },
+    });
+
+    // At this point the batch is finalized, its ref is cleared.
+    // Verify there's 1 batch with 3 tools, no orphan duplication.
+    let batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(1);
+    expect(batches[0].querySelectorAll(".gsd-tool-segment[data-tool-id]").length).toBe(3);
+
+    // No tool segments should exist outside the batch
+    const turnEl = messagesContainer.querySelector(".gsd-assistant-turn");
+    if (turnEl) {
+      const directToolSegments = Array.from(turnEl.children).filter(
+        (el) => el.classList.contains("gsd-tool-segment"),
+      );
+      expect(directToolSegments.length).toBe(0);
+    }
+
+    // agent_end: finalize the turn
+    sendMessage({ type: "agent_end" });
+
+    // After agent_end, still 1 batch with 3 tools, no duplication
+    batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(1);
+    expect(batches[0].querySelectorAll(".gsd-tool-segment[data-tool-id]").length).toBe(3);
+
+    // No tool segments outside the batch after finalization
+    const turnElAfter = messagesContainer.querySelector(".gsd-assistant-turn");
+    if (turnElAfter) {
+      const directToolSegments = Array.from(turnElAfter.children).filter(
+        (el) => el.classList.contains("gsd-tool-segment"),
+      );
+      expect(directToolSegments.length).toBe(0);
+    }
+
+    // Each tool segment should appear exactly once in the entire turn
+    for (const t of tools) {
+      const allSegments = messagesContainer.querySelectorAll(`.gsd-tool-segment[data-tool-id="${t.id}"]`);
+      expect(allSegments.length).toBe(1);
+    }
+  });
+
+  it("REGRESSION: multi-message turn with mid-stream finalizations must not create orphaned batches at agent_end", () => {
+    // Scenario: 2 separate API messages, each with 3 tools. Text between them
+    // finalizes the first batch. After all tools complete and agent_end fires,
+    // there should be exactly 2 batches (one per message), no orphans.
+    sendMessage({ type: "agent_start" });
+
+    // ── Message 1: 3 tools ──
+    sendMessage({ type: "message_start" });
+    const wave1 = [
+      { id: "m1", name: "Bash" },
+      { id: "m2", name: "Read" },
+      { id: "m3", name: "Grep" },
+    ];
+    for (const t of wave1) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    sendMessage(msgEndWithTools(wave1));
+    for (const t of wave1) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave1) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // ── Message 2: narration then 3 more tools ──
+    sendMessage({ type: "message_start" });
+    // This text_delta should finalize/seal the wave1 batch
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Now doing wave 2." },
+    });
+    const wave2 = [
+      { id: "m4", name: "Bash" },
+      { id: "m5", name: "Bash" },
+      { id: "m6", name: "Write" },
+    ];
+    for (const t of wave2) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    sendMessage(msgEndWithTools(wave2));
+    for (const t of wave2) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave2) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // Text after wave 2 — this finalizes wave 2's batch
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "All done now." },
+    });
+
+    // Before agent_end: should have 2 batches
+    let batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(2);
+
+    // agent_end
+    sendMessage({ type: "agent_end" });
+
+    // After agent_end: still 2 batches, no orphan duplication
+    batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(2);
+
+    // Each tool segment appears exactly once
+    for (const t of [...wave1, ...wave2]) {
+      const segs = messagesContainer.querySelectorAll(`.gsd-tool-segment[data-tool-id="${t.id}"]`);
+      expect(segs.length).toBe(1);
+    }
+
+    // Verify wave1 tools are in first batch, wave2 in second
+    const batch1Ids = Array.from(batches[0].querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+      .map(el => el.dataset.toolId!).sort();
+    const batch2Ids = Array.from(batches[1].querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+      .map(el => el.dataset.toolId!).sort();
+    expect(batch1Ids).toEqual(["m1", "m2", "m3"]);
+    expect(batch2Ids).toEqual(["m4", "m5", "m6"]);
+  });
+
+  it("REGRESSION: tool_execution_start must not pull completed-batch tools into a later batch", () => {
+    // Root cause of the "all tools collapse to first container at turn end" bug:
+    // message_end for wave 1 creates batch {A,B,C} and finalizes it. Wave 2
+    // message_end creates batch {D,E}. Then tool_execution_start for A fires —
+    // A.isParallel is true, A is not in a sealed batch, so the handler tries to
+    // add it to the active batch ({D,E}), pulling it out of its completed batch.
+    // Fix: isInCompletedBatch() checks the DOM for .gsd-parallel-batch.done ancestors.
+    sendMessage({ type: "agent_start" });
+
+    // ── Wave 1: 3 tools, fully complete ──
+    sendMessage({ type: "message_start" });
+    const wave1 = [
+      { id: "cb1", name: "Read" },
+      { id: "cb2", name: "Glob" },
+      { id: "cb3", name: "Grep" },
+    ];
+    for (const t of wave1) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    sendMessage(msgEndWithTools(wave1));
+    for (const t of wave1) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+    for (const t of wave1) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // ── Wave 2: 2 tools ──
+    sendMessage({ type: "message_start" });
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Now wave 2." },
+    });
+    const wave2 = [
+      { id: "cb4", name: "Bash" },
+      { id: "cb5", name: "Bash" },
+    ];
+    for (const t of wave2) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+    sendMessage(msgEndWithTools(wave2));
+
+    // CRITICAL: tool_execution_start for wave 2 fires — this used to trigger
+    // the bug where wave 1 tools got pulled into wave 2's batch.
+    for (const t of wave2) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    // Also simulate late tool_execution_start for wave 1 tools (backend quirk)
+    for (const t of wave1) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    // Must have 2 separate batches
+    let batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(2);
+
+    // Wave 1 tools stay in their batch
+    const batch1Ids = Array.from(batches[0].querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+      .map(el => el.dataset.toolId!).sort();
+    expect(batch1Ids).toEqual(["cb1", "cb2", "cb3"]);
+
+    // Wave 2 tools stay in their batch
+    const batch2Ids = Array.from(batches[1].querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+      .map(el => el.dataset.toolId!).sort();
+    expect(batch2Ids).toEqual(["cb4", "cb5"]);
+
+    // agent_end must not merge them
+    sendMessage({ type: "agent_end" });
+    batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(2);
+  });
+
+  it("REGRESSION: tool_execution events arriving AFTER batch finalized by text_delta must not create duplicate batch", () => {
+    // Scenario: streaming creates batch → text_delta finalizes → clearFinalizedBatch
+    // → tool_execution_start arrives late → syncBatchState might create a new batch
+    // while the old one is still in the DOM as an orphan.
+    sendMessage({ type: "agent_start" });
+    sendMessage({ type: "message_start" });
+
+    const tools = [
+      { id: "late1", name: "Bash" },
+      { id: "late2", name: "Bash" },
+      { id: "late3", name: "Read" },
+    ];
+
+    // Streaming creates tool segments
+    for (const t of tools) {
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          toolCall: { type: "toolCall", id: t.id, name: t.name },
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", id: t.id, name: t.name }] },
+        },
+      });
+    }
+
+    // message_end with the 3 tools
+    sendMessage(msgEndWithTools(tools));
+
+    // Text delta BEFORE execution events — finalizes the batch
+    sendMessage({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Running tools..." },
+    });
+
+    // Now tool_execution_start events arrive (late, after batch already finalized)
+    for (const t of tools) {
+      sendMessage({ type: "tool_execution_start", toolCallId: t.id, toolName: t.name, args: {} });
+    }
+
+    // Check: should still be 1 batch, not 2
+    let batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(1);
+
+    // Tools complete
+    for (const t of tools) {
+      sendMessage({
+        type: "tool_execution_end",
+        toolCallId: t.id,
+        isError: false,
+        durationMs: 50,
+        result: { content: [{ text: "ok" }] },
+      });
+    }
+
+    // agent_end
+    sendMessage({ type: "agent_end" });
+
+    // After finalization: 1 batch with all 3 tools
+    batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+    expect(batches.length).toBe(1);
+    expect(batches[0].querySelectorAll(".gsd-tool-segment[data-tool-id]").length).toBe(3);
+
+    // No duplicate tool segments
+    for (const t of tools) {
+      const segs = messagesContainer.querySelectorAll(`.gsd-tool-segment[data-tool-id="${t.id}"]`);
+      expect(segs.length).toBe(1);
+    }
   });
 });

--- a/src/webview/handlers/__tests__/state-handlers.test.ts
+++ b/src/webview/handlers/__tests__/state-handlers.test.ts
@@ -29,6 +29,8 @@ vi.mock("../../renderer", () => ({
   unsealBatchesOverlapping: vi.fn(),
   disbandOrphanedBatches: vi.fn(),
   getSealedBatchCount: vi.fn(() => 0),
+  getSealedBatchWaves: vi.fn(() => []),
+  getCurrentTurnElement: vi.fn(() => null),
   reopenParallelBatch: vi.fn(),
   appendServerToolSegment: vi.fn(),
   completeServerToolSegment: vi.fn(),

--- a/src/webview/handlers/__tests__/state-handlers.test.ts
+++ b/src/webview/handlers/__tests__/state-handlers.test.ts
@@ -22,7 +22,19 @@ vi.mock("../../renderer", () => ({
   sealActiveBatch: vi.fn(() => null),
   tickSealedBatches: vi.fn(),
   isInSealedBatch: vi.fn(() => false),
+  isInCompletedBatch: vi.fn(() => false),
   finalizeAllSealedBatches: vi.fn(),
+  clearFinalizedBatch: vi.fn(),
+  disbandActiveBatch: vi.fn(),
+  unsealBatchesOverlapping: vi.fn(),
+  disbandOrphanedBatches: vi.fn(),
+  getSealedBatchCount: vi.fn(() => 0),
+  reopenParallelBatch: vi.fn(),
+  appendServerToolSegment: vi.fn(),
+  completeServerToolSegment: vi.fn(),
+  reattachTurnElement: vi.fn(),
+  patchToolBlock: vi.fn(),
+  init: vi.fn(),
 }));
 
 vi.mock("../../session-history", () => ({

--- a/src/webview/handlers/__tests__/streaming-handlers.test.ts
+++ b/src/webview/handlers/__tests__/streaming-handlers.test.ts
@@ -26,7 +26,19 @@ vi.mock("../../renderer", () => ({
   sealActiveBatch: vi.fn(() => null),
   tickSealedBatches: vi.fn(),
   isInSealedBatch: vi.fn(() => false),
+  isInCompletedBatch: vi.fn(() => false),
   finalizeAllSealedBatches: vi.fn(),
+  clearFinalizedBatch: vi.fn(),
+  disbandActiveBatch: vi.fn(),
+  unsealBatchesOverlapping: vi.fn(),
+  disbandOrphanedBatches: vi.fn(),
+  getSealedBatchCount: vi.fn(() => 0),
+  reopenParallelBatch: vi.fn(),
+  appendServerToolSegment: vi.fn(),
+  completeServerToolSegment: vi.fn(),
+  reattachTurnElement: vi.fn(),
+  patchToolBlock: vi.fn(),
+  init: vi.fn(),
 }));
 
 vi.mock("../../session-history", () => ({

--- a/src/webview/handlers/__tests__/streaming-handlers.test.ts
+++ b/src/webview/handlers/__tests__/streaming-handlers.test.ts
@@ -33,6 +33,8 @@ vi.mock("../../renderer", () => ({
   unsealBatchesOverlapping: vi.fn(),
   disbandOrphanedBatches: vi.fn(),
   getSealedBatchCount: vi.fn(() => 0),
+  getSealedBatchWaves: vi.fn(() => []),
+  getCurrentTurnElement: vi.fn(() => null),
   reopenParallelBatch: vi.fn(),
   appendServerToolSegment: vi.fn(),
   completeServerToolSegment: vi.fn(),

--- a/src/webview/handlers/__tests__/tool-execution-handlers.test.ts
+++ b/src/webview/handlers/__tests__/tool-execution-handlers.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../renderer", () => ({
   sealActiveBatch: vi.fn(() => null),
   tickSealedBatches: vi.fn(),
   isInSealedBatch: vi.fn(() => false),
+  isInCompletedBatch: vi.fn(() => false),
   finalizeAllSealedBatches: vi.fn(),
 }));
 

--- a/src/webview/handlers/__tests__/ui-notification-handlers.test.ts
+++ b/src/webview/handlers/__tests__/ui-notification-handlers.test.ts
@@ -22,6 +22,7 @@ vi.mock("../../renderer", () => ({
   sealActiveBatch: vi.fn(() => null),
   tickSealedBatches: vi.fn(),
   isInSealedBatch: vi.fn(() => false),
+  isInCompletedBatch: vi.fn(() => false),
   finalizeAllSealedBatches: vi.fn(),
 }));
 

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -473,6 +473,10 @@ function handleMessage(event: MessageEvent): void {
         uiDialogs.expireAllPending("Agent finished");
       }
       document.querySelectorAll(".gsd-steer-note").forEach((el) => el.remove());
+      {
+        const batchesBefore = messagesContainer.querySelectorAll(".gsd-parallel-batch").length;
+        console.debug(`[gsd:parallel] agent_end: DOM batches=${batchesBefore}, activeBatch=${!!activeBatchToolIds}, sealed=${renderer.getSealedBatchCount?.() ?? -1}`);
+      }
       if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
       if (activeBatchToolIds) { renderer.finalizeParallelBatch(lastMessageUsage); }
       renderer.finalizeAllSealedBatches(lastMessageUsage);
@@ -480,6 +484,10 @@ function handleMessage(event: MessageEvent): void {
       messageParallelToolIds = null;
       renderer.clearActiveBatch();
       renderer.finalizeCurrentTurn();
+      {
+        const batchesAfter = messagesContainer.querySelectorAll(".gsd-parallel-batch").length;
+        console.debug(`[gsd:parallel] agent_end: DOM batches after finalize=${batchesAfter}`);
+      }
       updateInputUI();
       updateOverlayIndicators();
       vscode.postMessage({ type: "get_session_stats" });
@@ -527,6 +535,10 @@ function handleMessage(event: MessageEvent): void {
         }
         activeBatchToolIds = null;
       }
+      // Clear the finalized batch reference so the next wave's syncBatchState
+      // cannot reopen it. Each API message is a distinct thought cycle — its
+      // tools must form a new batch, never extend a prior message's batch.
+      renderer.clearFinalizedBatch();
       // Reset per-message parallel tracking — each message gets its own set
       messageParallelToolIds = null;
       lastMessageUsage = null;
@@ -565,11 +577,11 @@ function handleMessage(event: MessageEvent): void {
           // inside that box and the batch auto-finalizes on its own when they
           // end. Any new tool wave starts a fresh batch below this narration.
           if (activeBatchToolIds) {
-            if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
             const allDone = [...activeBatchToolIds].every(id => {
               const t = state.currentTurn?.toolCalls.get(id);
               return t && !t.isRunning;
             });
+            if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
             if (allDone) {
               console.debug(`[gsd:parallel] text_delta: finalizing batch (${activeBatchToolIds.size} tools) — all done`);
               renderer.finalizeParallelBatch(lastMessageUsage);
@@ -578,18 +590,18 @@ function handleMessage(event: MessageEvent): void {
               renderer.sealActiveBatch();
             }
             activeBatchToolIds = null;
+            renderer.clearFinalizedBatch();
           }
           renderer.appendToTextSegment("text", text);
         } else if (delta.type === "thinking_delta" && delta.delta) {
           // Thinking is also a thought-cycle boundary — seal/finalize any
-          // active batch so new tools after the thinking block open a fresh
-          // one. Mirrors text_delta seal logic.
+          // active batch so new tools after the thinking block open a fresh one.
           if (activeBatchToolIds) {
-            if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
             const allDone = [...activeBatchToolIds].every(id => {
               const t = state.currentTurn?.toolCalls.get(id);
               return t && !t.isRunning;
             });
+            if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
             if (allDone) {
               console.debug(`[gsd:parallel] thinking_delta: finalizing batch (${activeBatchToolIds.size} tools) — all done`);
               renderer.finalizeParallelBatch(lastMessageUsage);
@@ -598,6 +610,7 @@ function handleMessage(event: MessageEvent): void {
               renderer.sealActiveBatch();
             }
             activeBatchToolIds = null;
+            renderer.clearFinalizedBatch();
           }
           // Detect thinking blocks — if we see one, thinking is active.
           // Only auto-set when we genuinely have no level info (null/undefined).
@@ -670,7 +683,7 @@ function handleMessage(event: MessageEvent): void {
                 // shouldn't be pulled into this wave's batch.
                 const streamingRunning: ToolCallState[] = [];
                 for (const other of turn.toolCalls.values()) {
-                  if (other.isRunning && other.id !== block.id && !renderer.isInSealedBatch(other.id)) {
+                  if (other.isRunning && other.id !== block.id && !renderer.isInSealedBatch(other.id) && !renderer.isInCompletedBatch(other.id)) {
                     streamingRunning.push(other);
                   }
                 }
@@ -707,6 +720,7 @@ function handleMessage(event: MessageEvent): void {
                       if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
                       console.debug(`[gsd:parallel] toolcall_start: stale batch (${activeBatchToolIds.size} done) — finalizing before new wave`);
                       renderer.finalizeParallelBatch(lastMessageUsage);
+                      renderer.clearFinalizedBatch();
                       activeBatchToolIds = null;
                     } else {
                       if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
@@ -824,7 +838,7 @@ function handleMessage(event: MessageEvent): void {
     }
 
     case "message_end": {
-      const endData = msg;
+          const endData = msg;
       const endMsg = endData.message;
       // Extract definitive parallel tool IDs from message content blocks.
       // All tool_use blocks in a single API message are parallel by definition.
@@ -875,61 +889,106 @@ function handleMessage(event: MessageEvent): void {
           state.currentTurn.segments.push({ type: "tool", toolCallId: bId });
           renderer.appendToolSegmentElement(tc, segIdx);
         }
-        // Filter out tools that already belong to a sealed batch (prior wave).
-        // A single API message may contain multiple waves separated by text/thinking
-        // blocks — those thought-cycle boundaries sealed the earlier waves, so we
-        // must not pull their tools back into the current wave's batch.
-        const postSealedToolIds = toolIds.filter(id => !renderer.isInSealedBatch(id));
-        if (postSealedToolIds.length < toolIds.length) {
-          console.debug(`[gsd:parallel] message_end: ${toolIds.length - postSealedToolIds.length} tools already in sealed batches — excluding from current wave`);
-        }
-        if (postSealedToolIds.length >= 2) {
-          messageParallelToolIds = new Set(postSealedToolIds);
-          // Mark tools in the current (post-narration) wave as parallel
-          for (const toolId of postSealedToolIds) {
-            const tc = state.currentTurn.toolCalls.get(toolId);
-            if (tc && !tc.isParallel) {
-              tc.isParallel = true;
-              renderer.updateToolSegmentElement(toolId);
+        // Split tool IDs into waves separated by text/thinking blocks.
+        // A single API message may contain multiple tool waves with narration
+        // between them (e.g. "Wave 1 done. Wave 2:"). Each contiguous run of
+        // tool blocks is a separate parallel batch.
+        const toolWaves: string[][] = [];
+        let currentWave: string[] = [];
+        for (const block of blocks) {
+          const bType = (block as any).type;
+          if (toolBlockTypes.has(bType)) {
+            const bId = (block as any).id;
+            if (bId) currentWave.push(bId);
+          } else if (bType === "text" || bType === "thinking") {
+            if (currentWave.length > 0) {
+              toolWaves.push(currentWave);
+              currentWave = [];
             }
           }
-          // If the existing batch is disjoint from the new wave, split — this
-          // message_end is a definitive wave boundary from the provider side.
-          // A disjoint tool-id set means the model has moved on to a new wave;
-          // merging them would collapse sequential responses into one giant
-          // batch (the "162 tools in one block" production bug). The prior
-          // batch may still have running members (long-running Agent/Task
-          // tools) — seal it so those keep their spinner inside the closed
-          // batch and finalize on their own tool_execution_end.
+        }
+        if (currentWave.length > 0) toolWaves.push(currentWave);
+
+        console.debug(`[gsd:parallel] message_end: ${toolWaves.length} wave(s) from ${toolIds.length} tools, waves=${JSON.stringify(toolWaves)}`);
+        const domBatchesBefore = messagesContainer.querySelectorAll(".gsd-parallel-batch").length;
+        const sealedCount = renderer.getSealedBatchCount?.() ?? -1;
+        console.debug(`[gsd:parallel] message_end: DOM batches before reconcile: ${domBatchesBefore}, activeBatch=${!!activeBatchToolIds}, activeBatchSize=${activeBatchToolIds?.size ?? 0}, sealedBatches=${sealedCount}`);
+
+        // message_end content blocks are the authoritative wave structure.
+        // Disband streaming-created batches that overlap with the current
+        // message's tools, then rebuild from the authoritative wave structure.
+        // Batches from prior messages (disjoint tool IDs) are preserved.
+        const allMessageToolIds = new Set(toolIds);
+        if (toolWaves.length > 0 && toolWaves.some(w => w.length >= 2)) {
+          if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
+          // Disband the active batch ONLY if it overlaps with this message's tools.
+          // If it's from a prior message (disjoint IDs), seal it instead.
           if (activeBatchToolIds) {
-            const newIdSet = new Set(postSealedToolIds);
-            const overlaps = [...activeBatchToolIds].some(id => newIdSet.has(id));
-            if (!overlaps) {
-              const hasRunningMember = [...activeBatchToolIds].some(id => {
+            let activeOverlaps = false;
+            for (const id of activeBatchToolIds) {
+              if (allMessageToolIds.has(id)) { activeOverlaps = true; break; }
+            }
+            if (activeOverlaps) {
+              renderer.disbandActiveBatch();
+            } else {
+              const allDone = [...activeBatchToolIds].every(id => {
                 const t = state.currentTurn!.toolCalls.get(id);
-                return t?.isRunning;
+                return t && !t.isRunning;
               });
-              if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
-              if (hasRunningMember) {
-                console.debug(`[gsd:parallel] message_end: disjoint new wave (${activeBatchToolIds.size} prior, some running) — sealing before new wave`);
-                renderer.sealActiveBatch();
-              } else {
-                console.debug(`[gsd:parallel] message_end: disjoint new wave (${activeBatchToolIds.size} done) — finalizing before new wave`);
+              if (allDone) {
                 renderer.finalizeParallelBatch(lastMessageUsage);
+              } else {
+                renderer.sealActiveBatch();
+              }
+            }
+            activeBatchToolIds = null;
+            renderer.clearFinalizedBatch();
+          }
+          // Unseal any sealed batches whose tools overlap with this message's
+          // tools — those were prematurely sealed by streaming text_delta events
+          // within this message and need to be rebuilt per the authoritative waves.
+          renderer.unsealBatchesOverlapping(allMessageToolIds);
+          renderer.disbandOrphanedBatches(allMessageToolIds);
+
+          for (let wi = 0; wi < toolWaves.length; wi++) {
+            const wave = toolWaves[wi];
+            if (wave.length < 2) continue;
+
+            for (const toolId of wave) {
+              const tc = state.currentTurn.toolCalls.get(toolId);
+              if (tc && !tc.isParallel) {
+                tc.isParallel = true;
+                renderer.updateToolSegmentElement(toolId);
+              }
+            }
+
+            // Close the prior wave's batch before starting this one
+            if (activeBatchToolIds) {
+              const allDone = [...activeBatchToolIds].every(id => {
+                const t = state.currentTurn!.toolCalls.get(id);
+                return t && !t.isRunning;
+              });
+              if (allDone) {
+                renderer.finalizeParallelBatch(lastMessageUsage);
+              } else {
+                renderer.sealActiveBatch();
               }
               activeBatchToolIds = null;
+              renderer.clearFinalizedBatch();
             }
+
+            activeBatchToolIds = new Set(wave);
+            renderer.syncBatchState(activeBatchToolIds);
           }
-          if (!activeBatchToolIds) {
-            activeBatchToolIds = new Set(postSealedToolIds);
-          } else {
-            // Batch exists from streaming — add any missing post-seal tools
-            for (const toolId of postSealedToolIds) {
-              activeBatchToolIds.add(toolId);
-            }
-          }
-          if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
-          renderer.syncBatchState(activeBatchToolIds);
+        }
+
+        const domBatchesAfter = messagesContainer.querySelectorAll(".gsd-parallel-batch").length;
+        console.debug(`[gsd:parallel] message_end: DOM batches after reconcile: ${domBatchesAfter}`);
+
+        // Set messageParallelToolIds to the LAST wave (for tool_execution_start lookups)
+        if (toolWaves.length > 0) {
+          const lastWave = toolWaves[toolWaves.length - 1];
+          messageParallelToolIds = lastWave.length >= 2 ? new Set(lastWave) : null;
         } else {
           messageParallelToolIds = null;
         }
@@ -1055,14 +1114,19 @@ function handleMessage(event: MessageEvent): void {
       const existingTc = state.currentTurn.toolCalls.get(data.toolCallId);
       if (existingTc) {
         existingTc.args = data.args || existingTc.args;
-        existingTc.isRunning = true;
+        // Don't re-mark as running if toolcall_end already completed this tool
+        // with externalResult — that would cause the tool to visually "restart"
+        // (checkmark → spinner → checkmark), looking like a duplicate.
+        if (!existingTc.endTime) {
+          existingTc.isRunning = true;
+        }
         if (isKnownParallel) existingTc.isParallel = true;
         // Parallelism is determined by what's actually running, not by segment
         // adjacency. A tool is parallel only if another tool is currently
         // running right now.
         if (!existingTc.isParallel) {
           for (const [, other] of state.currentTurn.toolCalls) {
-            if (other.isRunning && other.id !== existingTc.id && !renderer.isInSealedBatch(other.id)) {
+            if (other.isRunning && other.id !== existingTc.id && !renderer.isInSealedBatch(other.id) && !renderer.isInCompletedBatch(other.id)) {
               existingTc.isParallel = true;
               break;
             }
@@ -1071,10 +1135,9 @@ function handleMessage(event: MessageEvent): void {
         renderer.updateToolSegmentElement(existingTc.id);
 
         // Ensure tool joins the active batch if genuinely parallel.
-        // If an existing batch has no running members it's stale (only alive
-        // because of the finalize timer) — finalize it before starting a new
-        // wave.
-        if (isKnownParallel || existingTc.isParallel) {
+        // If the tool already belongs to a sealed batch (from multi-wave
+        // splitting in message_end), don't pull it into a different batch.
+        if ((isKnownParallel || existingTc.isParallel) && !renderer.isInSealedBatch(existingTc.id) && !renderer.isInCompletedBatch(existingTc.id)) {
           let batch = activeBatchToolIds;
           if (batch && !batch.has(existingTc.id)) {
             const hasRunningMember = [...batch].some(id => {
@@ -1084,6 +1147,7 @@ function handleMessage(event: MessageEvent): void {
             if (!hasRunningMember) {
               if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
               renderer.finalizeParallelBatch(lastMessageUsage);
+              renderer.clearFinalizedBatch();
               activeBatchToolIds = null;
               batch = null;
             }
@@ -1105,7 +1169,7 @@ function handleMessage(event: MessageEvent): void {
       // Sealed-batch tools are excluded so a new wave after narration doesn't absorb them.
       const runningTools: ToolCallState[] = [];
       for (const [, existing] of state.currentTurn.toolCalls) {
-        if (existing.isRunning && !renderer.isInSealedBatch(existing.id)) runningTools.push(existing);
+        if (existing.isRunning && !renderer.isInSealedBatch(existing.id) && !renderer.isInCompletedBatch(existing.id)) runningTools.push(existing);
       }
 
       const fallbackIsParallel = isKnownParallel || runningTools.length > 0;
@@ -1150,6 +1214,7 @@ function handleMessage(event: MessageEvent): void {
           if (!hasRunningMember) {
             if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
             renderer.finalizeParallelBatch(lastMessageUsage);
+            renderer.clearFinalizedBatch();
             activeBatchToolIds = null;
             batch = null;
           }
@@ -1674,6 +1739,9 @@ function handleMessage(event: MessageEvent): void {
       break;
     // extensions_ready: extension lifecycle — already handled by extension host
     case "extensions_ready":
+      break;
+    // session_state_changed: pi session lifecycle — handled by extension host
+    case "session_state_changed":
       break;
 
     default:

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -59,6 +59,8 @@ let autoResize: () => void;
 // Parallel batch tracking — tracks tool IDs in the current active batch
 let activeBatchToolIds: Set<string> | null = null;
 let batchFinalizeTimer: ReturnType<typeof setTimeout> | null = null;
+let batchDiagTimers: ReturnType<typeof setTimeout>[] = [];
+let batchDiagObserver: MutationObserver | null = null;
 // Definitive parallel tool IDs from the most recent message_end content blocks.
 // All tool_use blocks in a single API message are parallel by definition.
 let messageParallelToolIds: Set<string> | null = null;
@@ -430,6 +432,10 @@ function handleMessage(event: MessageEvent): void {
     }
 
     case "agent_start": {
+      batchDiagTimers.forEach(clearTimeout);
+      batchDiagTimers = [];
+      batchDiagObserver?.disconnect();
+      batchDiagObserver = null;
       if (uiDialogs.hasPending()) {
         uiDialogs.expireAllPending("New turn started");
       }
@@ -509,24 +515,27 @@ function handleMessage(event: MessageEvent): void {
           return { count: batches.length, audit };
         };
         const snap0 = batchDiagnostic();
-        const diagTimer1 = setTimeout(() => {
+        batchDiagTimers.forEach(clearTimeout);
+        batchDiagTimers = [];
+        batchDiagTimers.push(setTimeout(() => {
           const snap1 = batchDiagnostic();
           if (snap1.count !== snap0.count) {
             console.error(`[gsd:parallel] BATCH DRIFT +500ms: ${snap0.count} → ${snap1.count}\n  ${snap1.audit.join("\n  ")}`);
           } else {
             console.debug(`[gsd:parallel] +500ms: stable at ${snap1.count} batches`);
           }
-        }, 500);
-        const diagTimer2 = setTimeout(() => {
+        }, 500));
+        batchDiagTimers.push(setTimeout(() => {
           const snap2 = batchDiagnostic();
           if (snap2.count !== snap0.count) {
             console.error(`[gsd:parallel] BATCH DRIFT +2s: ${snap0.count} → ${snap2.count}\n  ${snap2.audit.join("\n  ")}`);
           } else {
             console.debug(`[gsd:parallel] +2s: stable at ${snap2.count} batches`);
           }
-        }, 2000);
+        }, 2000));
 
-        const batchObserver = new MutationObserver((mutations) => {
+        batchDiagObserver?.disconnect();
+        batchDiagObserver = new MutationObserver((mutations) => {
           for (const m of mutations) {
             for (const removed of Array.from(m.removedNodes)) {
               if (removed instanceof HTMLElement && removed.classList?.contains("gsd-parallel-batch")) {
@@ -544,8 +553,13 @@ function handleMessage(event: MessageEvent): void {
             }
           }
         });
-        batchObserver.observe(scope, { childList: true, subtree: true });
-        setTimeout(() => { batchObserver.disconnect(); clearTimeout(diagTimer1); clearTimeout(diagTimer2); }, 5000);
+        batchDiagObserver.observe(scope, { childList: true, subtree: true });
+        batchDiagTimers.push(setTimeout(() => {
+          batchDiagObserver?.disconnect();
+          batchDiagObserver = null;
+          batchDiagTimers.forEach(clearTimeout);
+          batchDiagTimers = [];
+        }, 5000));
       }
       updateInputUI();
       updateOverlayIndicators();

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -487,18 +487,19 @@ function handleMessage(event: MessageEvent): void {
       activeBatchToolIds = null;
       messageParallelToolIds = null;
       renderer.clearActiveBatch();
+      const finishedTurnEl = renderer.getCurrentTurnElement();
       renderer.finalizeCurrentTurn();
       {
-        const batchesAfter = messagesContainer.querySelectorAll(".gsd-parallel-batch").length;
-        const batchAuditAfter = Array.from(messagesContainer.querySelectorAll<HTMLElement>(".gsd-parallel-batch")).map((b, i) => {
+        const scope = finishedTurnEl ?? messagesContainer;
+        const batchesAfter = scope.querySelectorAll(".gsd-parallel-batch").length;
+        const batchAuditAfter = Array.from(scope.querySelectorAll<HTMLElement>(".gsd-parallel-batch")).map((b, i) => {
           const ids = Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]")).map(el => el.dataset.toolId);
           return `batch${i}(${b.classList.contains("done") ? "done" : "other"}): [${ids.join(",")}]`;
         });
         console.warn(`[gsd:parallel] agent_end AFTER: DOM batches=${batchesAfter}\n  ${batchAuditAfter.join("\n  ")}`);
 
-        // Diagnostic: watch for post-agent_end batch mutations
         const batchDiagnostic = () => {
-          const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+          const batches = scope.querySelectorAll(".gsd-parallel-batch");
           const audit = Array.from(batches).map((b, i) => {
             const el = b as HTMLElement;
             const ids = Array.from(el.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]")).map(e => e.dataset.toolId);
@@ -508,7 +509,7 @@ function handleMessage(event: MessageEvent): void {
           return { count: batches.length, audit };
         };
         const snap0 = batchDiagnostic();
-        setTimeout(() => {
+        const diagTimer1 = setTimeout(() => {
           const snap1 = batchDiagnostic();
           if (snap1.count !== snap0.count) {
             console.error(`[gsd:parallel] BATCH DRIFT +500ms: ${snap0.count} → ${snap1.count}\n  ${snap1.audit.join("\n  ")}`);
@@ -516,7 +517,7 @@ function handleMessage(event: MessageEvent): void {
             console.debug(`[gsd:parallel] +500ms: stable at ${snap1.count} batches`);
           }
         }, 500);
-        setTimeout(() => {
+        const diagTimer2 = setTimeout(() => {
           const snap2 = batchDiagnostic();
           if (snap2.count !== snap0.count) {
             console.error(`[gsd:parallel] BATCH DRIFT +2s: ${snap0.count} → ${snap2.count}\n  ${snap2.audit.join("\n  ")}`);
@@ -525,7 +526,6 @@ function handleMessage(event: MessageEvent): void {
           }
         }, 2000);
 
-        // MutationObserver: catch the exact moment a batch is removed or reparented
         const batchObserver = new MutationObserver((mutations) => {
           for (const m of mutations) {
             for (const removed of Array.from(m.removedNodes)) {
@@ -544,8 +544,8 @@ function handleMessage(event: MessageEvent): void {
             }
           }
         });
-        batchObserver.observe(messagesContainer, { childList: true, subtree: true });
-        setTimeout(() => batchObserver.disconnect(), 5000);
+        batchObserver.observe(scope, { childList: true, subtree: true });
+        setTimeout(() => { batchObserver.disconnect(); clearTimeout(diagTimer1); clearTimeout(diagTimer2); }, 5000);
       }
       updateInputUI();
       updateOverlayIndicators();
@@ -937,6 +937,10 @@ function handleMessage(event: MessageEvent): void {
           if (bType !== "serverToolUse" && bType !== "server_tool_use") continue;
           const bId = (block as any).id as string | undefined;
           if (!bId || state.currentTurn.toolCalls.has(bId)) continue;
+          const alreadyHasSegment = state.currentTurn.segments.some(
+            s => (s.type === "server_tool" && s.serverToolId === bId) || (s.type === "tool" && s.toolCallId === bId)
+          );
+          if (alreadyHasSegment) continue;
           const input = (block as any).input ?? (block as any).arguments ?? {};
           const tc: ToolCallState = {
             id: bId,

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -475,7 +475,11 @@ function handleMessage(event: MessageEvent): void {
       document.querySelectorAll(".gsd-steer-note").forEach((el) => el.remove());
       {
         const batchesBefore = messagesContainer.querySelectorAll(".gsd-parallel-batch").length;
-        console.debug(`[gsd:parallel] agent_end: DOM batches=${batchesBefore}, activeBatch=${!!activeBatchToolIds}, sealed=${renderer.getSealedBatchCount?.() ?? -1}`);
+        const batchAudit = Array.from(messagesContainer.querySelectorAll<HTMLElement>(".gsd-parallel-batch")).map((b, i) => {
+          const ids = Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]")).map(el => el.dataset.toolId);
+          return `batch${i}(${b.classList.contains("done") ? "done" : b.classList.contains("running") ? "running" : "other"}): [${ids.join(",")}]`;
+        });
+        console.warn(`[gsd:parallel] agent_end: DOM batches=${batchesBefore}, activeBatch=${!!activeBatchToolIds}, activeBatchSize=${activeBatchToolIds?.size ?? 0}, sealed=${renderer.getSealedBatchCount?.() ?? -1}\n  ${batchAudit.join("\n  ")}`);
       }
       if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
       if (activeBatchToolIds) { renderer.finalizeParallelBatch(lastMessageUsage); }
@@ -486,7 +490,62 @@ function handleMessage(event: MessageEvent): void {
       renderer.finalizeCurrentTurn();
       {
         const batchesAfter = messagesContainer.querySelectorAll(".gsd-parallel-batch").length;
-        console.debug(`[gsd:parallel] agent_end: DOM batches after finalize=${batchesAfter}`);
+        const batchAuditAfter = Array.from(messagesContainer.querySelectorAll<HTMLElement>(".gsd-parallel-batch")).map((b, i) => {
+          const ids = Array.from(b.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]")).map(el => el.dataset.toolId);
+          return `batch${i}(${b.classList.contains("done") ? "done" : "other"}): [${ids.join(",")}]`;
+        });
+        console.warn(`[gsd:parallel] agent_end AFTER: DOM batches=${batchesAfter}\n  ${batchAuditAfter.join("\n  ")}`);
+
+        // Diagnostic: watch for post-agent_end batch mutations
+        const batchDiagnostic = () => {
+          const batches = messagesContainer.querySelectorAll(".gsd-parallel-batch");
+          const audit = Array.from(batches).map((b, i) => {
+            const el = b as HTMLElement;
+            const ids = Array.from(el.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]")).map(e => e.dataset.toolId);
+            const parentTag = el.parentElement?.className ?? "??";
+            return `batch${i}(${ids.length} tools, parent=${parentTag})`;
+          });
+          return { count: batches.length, audit };
+        };
+        const snap0 = batchDiagnostic();
+        setTimeout(() => {
+          const snap1 = batchDiagnostic();
+          if (snap1.count !== snap0.count) {
+            console.error(`[gsd:parallel] BATCH DRIFT +500ms: ${snap0.count} → ${snap1.count}\n  ${snap1.audit.join("\n  ")}`);
+          } else {
+            console.debug(`[gsd:parallel] +500ms: stable at ${snap1.count} batches`);
+          }
+        }, 500);
+        setTimeout(() => {
+          const snap2 = batchDiagnostic();
+          if (snap2.count !== snap0.count) {
+            console.error(`[gsd:parallel] BATCH DRIFT +2s: ${snap0.count} → ${snap2.count}\n  ${snap2.audit.join("\n  ")}`);
+          } else {
+            console.debug(`[gsd:parallel] +2s: stable at ${snap2.count} batches`);
+          }
+        }, 2000);
+
+        // MutationObserver: catch the exact moment a batch is removed or reparented
+        const batchObserver = new MutationObserver((mutations) => {
+          for (const m of mutations) {
+            for (const removed of Array.from(m.removedNodes)) {
+              if (removed instanceof HTMLElement && removed.classList?.contains("gsd-parallel-batch")) {
+                const toolCount = removed.querySelectorAll(".gsd-tool-segment[data-tool-id]").length;
+                console.error(`[gsd:parallel] BATCH REMOVED: ${toolCount} tools, parentClass=${(m.target as HTMLElement).className}`);
+                console.trace("[gsd:parallel] removal stack");
+              }
+            }
+            for (const added of Array.from(m.addedNodes)) {
+              if (added instanceof HTMLElement && added.classList?.contains("gsd-parallel-batch")) {
+                const toolCount = added.querySelectorAll(".gsd-tool-segment[data-tool-id]").length;
+                console.error(`[gsd:parallel] BATCH ADDED post-agent_end: ${toolCount} tools`);
+                console.trace("[gsd:parallel] addition stack");
+              }
+            }
+          }
+        });
+        batchObserver.observe(messagesContainer, { childList: true, subtree: true });
+        setTimeout(() => batchObserver.disconnect(), 5000);
       }
       updateInputUI();
       updateOverlayIndicators();
@@ -583,10 +642,10 @@ function handleMessage(event: MessageEvent): void {
             });
             if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
             if (allDone) {
-              console.debug(`[gsd:parallel] text_delta: finalizing batch (${activeBatchToolIds.size} tools) — all done`);
+              console.warn(`[gsd:parallel] text_delta: finalizing batch (${activeBatchToolIds.size} tools, ids=[${[...activeBatchToolIds].join(",")}]) — all done`);
               renderer.finalizeParallelBatch(lastMessageUsage);
             } else {
-              console.debug(`[gsd:parallel] text_delta: sealing batch (${activeBatchToolIds.size} tools) — some still running`);
+              console.warn(`[gsd:parallel] text_delta: sealing batch (${activeBatchToolIds.size} tools, ids=[${[...activeBatchToolIds].join(",")}]) — some still running`);
               renderer.sealActiveBatch();
             }
             activeBatchToolIds = null;
@@ -847,6 +906,12 @@ function handleMessage(event: MessageEvent): void {
       // dispatch or web_search. They co-occur with regular tool_use blocks in
       // the same message and MUST participate in the parallel-batch set,
       // otherwise the visible tool count undercounts reality.
+      if (!endMsg?.content && state.currentTurn) {
+        const turnToolCount = state.currentTurn.toolCalls.size;
+        if (turnToolCount > 0) {
+          console.warn(`[gsd:parallel] message_end: NO content blocks but ${turnToolCount} tools in turn — reconciliation SKIPPED. endMsg keys=${endMsg ? Object.keys(endMsg).join(",") : "null"}`);
+        }
+      }
       if (endMsg?.content && state.currentTurn) {
         const blocks = Array.isArray(endMsg.content) ? endMsg.content : [];
         console.debug(`[gsd:parallel] message_end: ${blocks.length} content blocks, types=[${blocks.map((b: any) => b.type).join(",")}]`);
@@ -909,6 +974,25 @@ function handleMessage(event: MessageEvent): void {
         }
         if (currentWave.length > 0) toolWaves.push(currentWave);
 
+        // The API may flatten multiple tool waves into a single contiguous
+        // block in message_end (no text/thinking separators). When streaming
+        // established more granular sealed batches, prefer that structure —
+        // the sealed batches were split by actual text_delta narration events.
+        const sealedWaves = renderer.getSealedBatchWaves();
+        const activeWave = activeBatchToolIds ? [...activeBatchToolIds] : [];
+        const allStreamingWaves = [...sealedWaves, ...(activeWave.length >= 2 ? [activeWave] : [])];
+        const allMessageToolIds = new Set(toolIds);
+        if (allStreamingWaves.length > toolWaves.length) {
+          const streamingToolIds = new Set(allStreamingWaves.flat());
+          const allStreamingInMessage = [...streamingToolIds].every(id => allMessageToolIds.has(id));
+          const allMessageInStreaming = [...allMessageToolIds].every(id => streamingToolIds.has(id));
+          if (allStreamingInMessage && allMessageInStreaming) {
+            console.debug(`[gsd:parallel] message_end: streaming batches (${allStreamingWaves.length}) more granular than API waves (${toolWaves.length}) — using streaming structure`);
+            toolWaves.length = 0;
+            toolWaves.push(...allStreamingWaves);
+          }
+        }
+
         console.debug(`[gsd:parallel] message_end: ${toolWaves.length} wave(s) from ${toolIds.length} tools, waves=${JSON.stringify(toolWaves)}`);
         const domBatchesBefore = messagesContainer.querySelectorAll(".gsd-parallel-batch").length;
         const sealedCount = renderer.getSealedBatchCount?.() ?? -1;
@@ -918,7 +1002,6 @@ function handleMessage(event: MessageEvent): void {
         // Disband streaming-created batches that overlap with the current
         // message's tools, then rebuild from the authoritative wave structure.
         // Batches from prior messages (disjoint tool IDs) are preserved.
-        const allMessageToolIds = new Set(toolIds);
         if (toolWaves.length > 0 && toolWaves.some(w => w.length >= 2)) {
           if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = null; }
           // Disband the active batch ONLY if it overlaps with this message's tools.

--- a/src/webview/render/batches.ts
+++ b/src/webview/render/batches.ts
@@ -370,7 +370,18 @@ export function sealActiveBatch(): Set<string> | null {
     if (id) toolIds.add(id);
   }
 
-  if (toolIds.size < 2) { activeBatchElement = null; return null; }
+  if (toolIds.size < 2) {
+    const parent = activeBatchElement.parentElement;
+    if (parent) {
+      const children = Array.from(content.children);
+      for (const child of children) {
+        parent.insertBefore(child, activeBatchElement);
+      }
+      activeBatchElement.remove();
+    }
+    activeBatchElement = null;
+    return null;
+  }
 
   sealedBatches.push({ element: activeBatchElement, toolIds });
   activeBatchElement = null;
@@ -430,6 +441,23 @@ export function updateBatchElapsed(): void {
 export function getActiveBatchElement(): HTMLElement | null { return activeBatchElement; }
 export function getFinalizedBatchElement(): HTMLElement | null { return finalizedBatchElement; }
 export function clearActiveBatch(): void { activeBatchElement = null; finalizedBatchElement = null; sealedBatches.length = 0; }
+export function clearFinalizedBatch(): void { finalizedBatchElement = null; }
+
+export function disbandActiveBatch(): void {
+  if (!activeBatchElement) return;
+  const parent = activeBatchElement.parentElement;
+  if (!parent) { activeBatchElement = null; return; }
+  const content = activeBatchElement.querySelector(".gsd-parallel-batch-content");
+  if (content) {
+    const children = Array.from(content.children);
+    for (const child of children) {
+      parent.insertBefore(child, activeBatchElement);
+    }
+  }
+  activeBatchElement.remove();
+  activeBatchElement = null;
+  finalizedBatchElement = null;
+}
 
 export function syncBatchState(trackedIds: Set<string>): void {
   const cte = getCurrentTurnElement();

--- a/src/webview/render/batches.ts
+++ b/src/webview/render/batches.ts
@@ -446,7 +446,7 @@ export function clearFinalizedBatch(): void { finalizedBatchElement = null; }
 export function disbandActiveBatch(): void {
   if (!activeBatchElement) return;
   const parent = activeBatchElement.parentElement;
-  if (!parent) { activeBatchElement = null; return; }
+  if (!parent) { activeBatchElement = null; finalizedBatchElement = null; return; }
   const content = activeBatchElement.querySelector(".gsd-parallel-batch-content");
   if (content) {
     const children = Array.from(content.children);

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -1188,7 +1188,18 @@ export function clearFinalizedBatch(): void {
 export function getSealedBatchCount(): number { return sealedBatches.length; }
 
 export function getSealedBatchWaves(): string[][] {
-  return sealedBatches.map(s => [...s.toolIds]);
+  const waves = sealedBatches.map(s => [...s.toolIds]);
+  const sealedIds = new Set(waves.flat());
+  const cte = getCurrentTurnElement();
+  if (cte) {
+    for (const batch of Array.from(cte.querySelectorAll<HTMLElement>(".gsd-parallel-batch.done"))) {
+      const ids = Array.from(batch.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]"))
+        .map(el => el.dataset.toolId!)
+        .filter(id => id && !sealedIds.has(id));
+      if (ids.length > 0) waves.push(ids);
+    }
+  }
+  return waves;
 }
 
 /** Remove the active batch container and return its children to the turn element.

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -38,7 +38,7 @@ import {
   collapseToolIntoGroup,
 } from "./tool-grouping";
 
-import { initStreaming as initStreamingModule } from "./render/streaming";
+import { initStreaming as initStreamingModule, resolveContainerLevelAnchor } from "./render/streaming";
 
 // ============================================================
 // Dependencies injected via init()
@@ -810,7 +810,8 @@ export function createParallelBatch(toolIds: string[]): void {
     // Fallback: append to current turn
     currentTurnElement.appendChild(batch);
   } else {
-    firstEl.parentNode!.insertBefore(batch, firstEl);
+    const anchor = resolveContainerLevelAnchor(currentTurnElement, firstEl);
+    anchor.parentNode!.insertBefore(batch, anchor);
   }
 
   // Reparent all tool segment elements into the batch content
@@ -1127,6 +1128,20 @@ export function isInSealedBatch(toolId: string): boolean {
 }
 
 /**
+ * Does the given tool already live inside a finalized (done) batch in the DOM?
+ * Finalized batches are no longer tracked by module variables — they exist only
+ * as `.gsd-parallel-batch.done` elements. This prevents tool_execution_start
+ * from pulling a tool out of its completed batch into a different active batch.
+ */
+export function isInCompletedBatch(toolId: string): boolean {
+  if (!currentTurnElement) return false;
+  const el = currentTurnElement.querySelector<HTMLElement>(
+    `.gsd-tool-segment[data-tool-id="${toolId}"]`,
+  );
+  return !!el?.closest(".gsd-parallel-batch.done");
+}
+
+/**
  * Finalize every sealed batch immediately (used on turn end / agent end when
  * we want everything resolved regardless of whether tools finished cleanly).
  */
@@ -1162,6 +1177,96 @@ export function clearActiveBatch(): void {
   activeBatchElement = null;
   finalizedBatchElement = null;
   sealedBatches.length = 0;
+}
+
+/** Clear only the finalized batch reference so the next wave cannot reopen it.
+ *  Called at message boundaries to enforce one-batch-per-message. */
+export function clearFinalizedBatch(): void {
+  finalizedBatchElement = null;
+}
+
+export function getSealedBatchCount(): number { return sealedBatches.length; }
+
+/** Remove the active batch container and return its children to the turn element.
+ *  Used when message_end reveals multi-wave content that was prematurely merged
+ *  during streaming. The children are placed back at the batch's DOM position so
+ *  subsequent per-wave syncBatchState calls can re-group them correctly. */
+export function disbandActiveBatch(): void {
+  if (!activeBatchElement) return;
+  const parent = activeBatchElement.parentElement;
+  if (!parent) { activeBatchElement = null; return; }
+  const content = activeBatchElement.querySelector(".gsd-parallel-batch-content");
+  if (content) {
+    const children = Array.from(content.children);
+    for (const child of children) {
+      parent.insertBefore(child, activeBatchElement);
+    }
+  }
+  activeBatchElement.remove();
+  activeBatchElement = null;
+  finalizedBatchElement = null;
+}
+
+/** Unseal and disband any sealed batches whose tool IDs overlap with the given
+ *  set. Returns the tools to the turn element so they can be re-grouped by the
+ *  authoritative wave structure from message_end. Sealed batches with no
+ *  overlapping tools (from prior messages) are preserved. */
+export function unsealBatchesOverlapping(toolIds: Set<string>): void {
+  for (let i = sealedBatches.length - 1; i >= 0; i--) {
+    const sealed = sealedBatches[i];
+    let overlaps = false;
+    for (const id of sealed.toolIds) {
+      if (toolIds.has(id)) { overlaps = true; break; }
+    }
+    if (!overlaps) continue;
+    const parent = sealed.element.parentElement;
+    if (parent) {
+      const content = sealed.element.querySelector(".gsd-parallel-batch-content");
+      if (content) {
+        const children = Array.from(content.children);
+        for (const child of children) {
+          parent.insertBefore(child, sealed.element);
+        }
+      }
+      sealed.element.remove();
+    }
+    sealedBatches.splice(i, 1);
+  }
+}
+
+/** Disband any DOM batch elements whose tool segments overlap with the given
+ *  set but are NOT tracked by activeBatchElement, finalizedBatchElement, or
+ *  sealedBatches. These "orphaned" batches appear when the text_delta handler
+ *  finalizes a batch mid-stream (finalizeParallelBatch → clearFinalizedBatch),
+ *  leaving the DOM element in place with no module reference. The message_end
+ *  reconciliation must clear them before rebuilding per the authoritative waves. */
+export function disbandOrphanedBatches(toolIds: Set<string>): void {
+  if (!currentTurnElement) return;
+  const allBatches = currentTurnElement.querySelectorAll<HTMLElement>(".gsd-parallel-batch");
+  for (const batch of Array.from(allBatches)) {
+    if (batch === activeBatchElement || batch === finalizedBatchElement) continue;
+    let isSealed = false;
+    for (const s of sealedBatches) { if (s.element === batch) { isSealed = true; break; } }
+    if (isSealed) continue;
+
+    const segments = batch.querySelectorAll<HTMLElement>(".gsd-tool-segment[data-tool-id]");
+    let overlaps = false;
+    for (const seg of Array.from(segments)) {
+      if (seg.dataset.toolId && toolIds.has(seg.dataset.toolId)) { overlaps = true; break; }
+    }
+    if (!overlaps) continue;
+
+    const parent = batch.parentElement;
+    if (parent) {
+      const content = batch.querySelector(".gsd-parallel-batch-content");
+      if (content) {
+        for (const child of Array.from(content.children)) {
+          parent.insertBefore(child, batch);
+        }
+      }
+      batch.remove();
+    }
+  }
 }
 
 /**
@@ -1249,8 +1354,9 @@ export function syncBatchState(trackedIds: Set<string>): void {
           firstEl = el;
         }
       }
-      if (firstEl && firstEl.parentNode) {
-        firstEl.parentNode.insertBefore(batch, firstEl);
+      if (firstEl) {
+        const anchor = resolveContainerLevelAnchor(currentTurnElement, firstEl);
+        anchor.parentNode!.insertBefore(batch, anchor);
       } else {
         currentTurnElement.appendChild(batch);
       }

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -1187,6 +1187,10 @@ export function clearFinalizedBatch(): void {
 
 export function getSealedBatchCount(): number { return sealedBatches.length; }
 
+export function getSealedBatchWaves(): string[][] {
+  return sealedBatches.map(s => [...s.toolIds]);
+}
+
 /** Remove the active batch container and return its children to the turn element.
  *  Used when message_end reveals multi-wave content that was prematurely merged
  *  during streaming. The children are placed back at the batch's DOM position so


### PR DESCRIPTION
## Summary
- When the Claude API flattens multiple sequential tool batches into a single contiguous block in `message_end`, the reconciler now preserves the more granular batch boundaries established during streaming (split by actual `text_delta` narration events) instead of collapsing them into one mega-batch.
- Adds `getSealedBatchWaves()` to renderer to expose sealed batch structure for reconciliation comparison.
- Enhanced diagnostic logging: batch audit trails with tool IDs, `MutationObserver` for post-`agent_end` drift detection, stability checks at +500ms and +2s.

## Test plan
- [x] Manually tested with 3 sequential parallel batches (2+2+2 tools) — all 3 batches preserved through agent_end and stable at +500ms/+2s
- [x] Console confirms `streaming batches (3) more granular than API waves (1) — using streaming structure` path is hit
- [x] No BATCH DRIFT or BATCH REMOVED errors in console
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented completed tool outputs from appearing to restart or losing their completion text/time.
  * Fixed narration and parallel-tool grouping so text and tool outputs split correctly across streaming and message boundaries, avoiding duplicate or orphaned segments.
  * Made batch finalisation more reliable during complex streaming and turn flows.

* **Tests**
  * Expanded end-to-end and unit tests for parallel-batch, streaming and tool-execution edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->