### PR TITLE
Sync: reconcile workspace changes with latest main

### DIFF
--- a/dist/meta-webview.json
+++ b/dist/meta-webview.json
@@ -343,7 +343,7 @@
       "format": "esm"
     },
     "src/webview/renderer.ts": {
-      "bytes": 88016,
+      "bytes": 88488,
       "imports": [
         {
           "path": "src/webview/state.ts",
@@ -514,7 +514,7 @@
       "format": "esm"
     },
     "src/webview/message-handler.ts": {
-      "bytes": 93665,
+      "bytes": 94543,
       "imports": [
         {
           "path": "src/webview/helpers.ts",
@@ -812,7 +812,7 @@
       "imports": [],
       "exports": [],
       "inputs": {},
-      "bytes": 953553
+      "bytes": 955749
     },
     "dist/webview/index.js": {
       "imports": [],
@@ -920,7 +920,7 @@
           "bytesInOutput": 232
         },
         "src/webview/renderer.ts": {
-          "bytesInOutput": 33008
+          "bytesInOutput": 33264
         },
         "src/webview/dashboard.ts": {
           "bytesInOutput": 10399
@@ -938,7 +938,7 @@
           "bytesInOutput": 6809
         },
         "src/webview/message-handler.ts": {
-          "bytesInOutput": 31665
+          "bytesInOutput": 31942
         },
         "src/webview/ui-updates.ts": {
           "bytesInOutput": 7858
@@ -947,7 +947,7 @@
           "bytesInOutput": 19106
         }
       },
-      "bytes": 245131
+      "bytes": 245664
     },
     "dist/webview/index.css.map": {
       "imports": [],

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -996,6 +996,9 @@ function handleMessage(event: MessageEvent): void {
         // block in message_end (no text/thinking separators). When streaming
         // established more granular sealed batches, prefer that structure —
         // the sealed batches were split by actual text_delta narration events.
+        // Streaming batches may only cover a subset of the message's tools
+        // (tools arriving individually between narration aren't batched), so
+        // we only require that streaming IDs are a subset of message IDs.
         const sealedWaves = renderer.getSealedBatchWaves();
         const activeWave = activeBatchToolIds ? [...activeBatchToolIds] : [];
         const allStreamingWaves = [...sealedWaves, ...(activeWave.length >= 2 ? [activeWave] : [])];
@@ -1003,8 +1006,7 @@ function handleMessage(event: MessageEvent): void {
         if (allStreamingWaves.length > toolWaves.length) {
           const streamingToolIds = new Set(allStreamingWaves.flat());
           const allStreamingInMessage = [...streamingToolIds].every(id => allMessageToolIds.has(id));
-          const allMessageInStreaming = [...allMessageToolIds].every(id => streamingToolIds.has(id));
-          if (allStreamingInMessage && allMessageInStreaming) {
+          if (allStreamingInMessage) {
             console.debug(`[gsd:parallel] message_end: streaming batches (${allStreamingWaves.length}) more granular than API waves (${toolWaves.length}) — using streaming structure`);
             toolWaves.length = 0;
             toolWaves.push(...allStreamingWaves);


### PR DESCRIPTION
## Summary\n- Reconcile local workspace deltas against latest `main`\n- Keep only intentional behavioral differences\n\n## Verification\n- npm run build\n- npx vitest run src/webview/__tests__/message-handler.test.ts src/webview/__tests__/model-picker.test.ts src/webview/handlers/__tests__/parallel-tools.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message reconciliation handling to better align streaming data with API responses. The system now treats streaming message structure as authoritative when reconciling tool information, allowing for more flexible processing of partial tool sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->