### PR TITLE
Fix Telegram sync failing after a group is upgraded to a supergroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Rokket GSD will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.69] — 2026-05-31
+
+### Fixed
+- **Telegram supergroup upgrades** — when a linked group is upgraded to a supergroup, its chat ID changes and the old one stops working. Sync now detects this, switches to the new ID, saves it, and retries automatically, so the sync button works without re-running setup. Previously every sync attempt failed with "group chat was upgraded to a supergroup chat" and created no topic.
+- **Repeated failed sync attempts** — a failed topic creation no longer consumes a topic number, so retries no longer produce escalating names like "Project #2 #3 #4".
+
 ## [0.3.63] — 2026-05-21
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rokket-gsd",
-	"version": "0.3.64",
+	"version": "0.3.69",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rokket-gsd",
-			"version": "0.3.64",
+			"version": "0.3.69",
 			"license": "MIT",
 			"dependencies": {
 				"dompurify": "^3.4.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rokket-gsd",
 	"displayName": "GSD Pi Premium GUI — RokketGSD",
 	"description": "The GSD Pi (OpenGSD) VS Code extension — AI coding agent with chat UI, multi-model support, 40+ tool visualizations, Telegram voice relay, parallel workers, and workflow automation. Also compatible with GSD V2.",
-	"version": "0.3.68",
+	"version": "0.3.69",
 	"publisher": "rokketek",
 	"license": "MIT",
 	"repository": {

--- a/src/extension/telegram/api.test.ts
+++ b/src/extension/telegram/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { TelegramApi, redactToken } from "./api";
+import { TelegramApi, redactToken, TelegramMigrationError } from "./api";
 
 const TOKEN = "123456:ABC-DEF";
 
@@ -181,6 +181,39 @@ describe("TelegramApi", () => {
 
       await expect(api.getMe()).rejects.toThrow("bot***");
       await expect(api.getMe()).rejects.not.toThrow(TOKEN);
+    });
+
+    it("throws TelegramMigrationError carrying the new chat ID on supergroup upgrade", async () => {
+      globalThis.fetch = mockFetch(
+        {
+          ok: false,
+          description: "Bad Request: group chat was upgraded to a supergroup chat",
+          parameters: { migrate_to_chat_id: -1001999888777 },
+        },
+        400,
+      );
+
+      await expect(api.createForumTopic(-100, "Test")).rejects.toBeInstanceOf(
+        TelegramMigrationError,
+      );
+    });
+
+    it("TelegramMigrationError exposes migrateToChatId, status, and description", async () => {
+      globalThis.fetch = mockFetch(
+        {
+          ok: false,
+          description: "Bad Request: group chat was upgraded to a supergroup chat",
+          parameters: { migrate_to_chat_id: -1001999888777 },
+        },
+        400,
+      );
+
+      const err = await api.createForumTopic(-100, "Test").catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(TelegramMigrationError);
+      const migErr = err as TelegramMigrationError;
+      expect(migErr.migrateToChatId).toBe(-1001999888777);
+      expect(migErr.status).toBe(400);
+      expect(migErr.description).toContain("supergroup");
     });
 
     it("includes retry_after hint", async () => {

--- a/src/extension/telegram/api.ts
+++ b/src/extension/telegram/api.ts
@@ -74,11 +74,31 @@ interface TelegramResponse<T> {
   ok: boolean;
   result?: T;
   description?: string;
-  parameters?: { retry_after?: number };
+  parameters?: { retry_after?: number; migrate_to_chat_id?: number };
 }
 
 export function redactToken(msg: string, token: string): string {
   return msg.replaceAll(token, "bot***");
+}
+
+/**
+ * Thrown when a request targets a group chat that Telegram has upgraded to a
+ * supergroup. The old chat ID is permanently invalid; `migrateToChatId` is the
+ * new ID Telegram returns under `parameters.migrate_to_chat_id`. Callers should
+ * update their stored chat ID to this value and retry. Carries no token, so it
+ * is safe to log without redaction.
+ */
+export class TelegramMigrationError extends Error {
+  constructor(
+    readonly migrateToChatId: number,
+    readonly status: number,
+    readonly description: string,
+  ) {
+    super(
+      `Telegram chat was upgraded to a supergroup — migrate to chat ID ${migrateToChatId}`,
+    );
+    this.name = "TelegramMigrationError";
+  }
 }
 
 export class TelegramApi {
@@ -120,6 +140,10 @@ export class TelegramApi {
 
     if (!response.ok || !data.ok) {
       const desc = data.description ?? "unknown error";
+      const migrateTo = data.parameters?.migrate_to_chat_id;
+      if (migrateTo != null) {
+        throw new TelegramMigrationError(migrateTo, response.status, desc);
+      }
       const retryHint =
         data.parameters?.retry_after != null
           ? ` (retry after ${data.parameters.retry_after}s)`

--- a/src/extension/telegram/bridge.ts
+++ b/src/extension/telegram/bridge.ts
@@ -117,6 +117,15 @@ export class TelegramBridge {
     this.streamingGranularity = value;
   }
 
+  /**
+   * Adopt a new chat ID after the group migrates to a supergroup, so all
+   * subsequent outbound calls (sendMessage, editMessageText, …) target the
+   * valid supergroup instead of the dead pre-migration ID.
+   */
+  setChatId(chatId: number | string): void {
+    this.chatId = chatId;
+  }
+
   setOnInboundMessage(cb: InboundMessageCallback): void {
     this.onInboundMessage = cb;
   }

--- a/src/extension/telegram/topicManager.test.ts
+++ b/src/extension/telegram/topicManager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TopicManager } from "./topicManager";
 import type { TelegramApi } from "./api";
+import { TelegramMigrationError } from "./api";
 import type { GlobalStateStore, TopicRegistryEntry } from "./topicManager";
 
 function createMockApi(): TelegramApi {
@@ -243,6 +244,53 @@ describe("TopicManager", () => {
       // second call returns -1 (syncing guard) or existing id
       expect(typeof r2).toBe("number");
       expect(api.createForumTopic).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("supergroup migration", () => {
+    const NEW_CHAT_ID = -1009999999999;
+
+    it("adopts the new chat ID, notifies the host, and retries once on migration", async () => {
+      const onChatMigrated = vi.fn();
+      (api.createForumTopic as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new TelegramMigrationError(NEW_CHAT_ID, 400, "group chat was upgraded to a supergroup chat"),
+      );
+      const m = new TopicManager(api, CHAT_ID, MACHINE_ID, undefined, undefined, onChatMigrated);
+
+      const threadId = await m.syncOn("s1", "MyProject");
+
+      expect(threadId).toBe(100);
+      expect(m.currentChatId).toBe(NEW_CHAT_ID);
+      expect(onChatMigrated).toHaveBeenCalledWith(NEW_CHAT_ID);
+      expect(api.createForumTopic).toHaveBeenCalledTimes(2);
+      expect(api.createForumTopic).toHaveBeenNthCalledWith(1, CHAT_ID, "MyProject");
+      expect(api.createForumTopic).toHaveBeenNthCalledWith(2, NEW_CHAT_ID, "MyProject");
+    });
+
+    it("propagates the error if the post-migration retry also fails", async () => {
+      const onChatMigrated = vi.fn();
+      (api.createForumTopic as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new TelegramMigrationError(NEW_CHAT_ID, 400, "upgraded"))
+        .mockRejectedValueOnce(new Error("still broken"));
+      const m = new TopicManager(api, CHAT_ID, MACHINE_ID, undefined, undefined, onChatMigrated);
+
+      await expect(m.syncOn("s1", "MyProject")).rejects.toThrow("still broken");
+      expect(m.currentChatId).toBe(NEW_CHAT_ID);
+      expect(onChatMigrated).toHaveBeenCalledWith(NEW_CHAT_ID);
+    });
+
+    it("does not burn a topic number when creation fails", async () => {
+      (api.createForumTopic as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("network down"),
+      );
+
+      await expect(manager.syncOn("s1", "MyProject")).rejects.toThrow("network down");
+
+      // The next successful sync is still the first topic — bare label, no "#2".
+      const threadId = await manager.syncOn("s2", "MyProject");
+      expect(threadId).toBe(100);
+      const lastName = (api.createForumTopic as ReturnType<typeof vi.fn>).mock.calls.at(-1)![1];
+      expect(lastName).toBe("MyProject");
     });
   });
 });

--- a/src/extension/telegram/topicManager.ts
+++ b/src/extension/telegram/topicManager.ts
@@ -1,4 +1,5 @@
 import type { TelegramApi, ForumTopic } from "./api";
+import { TelegramMigrationError } from "./api";
 
 const TELEGRAM_TOPIC_NAME_LIMIT = 128;
 const TOPIC_REGISTRY_KEY = "gsd.telegram.topicRegistry";
@@ -35,10 +36,11 @@ export class TopicManager {
 
   constructor(
     private readonly api: TelegramApi,
-    private readonly chatId: number | string,
+    private chatId: number | string,
     machineId: string,
     private readonly logger: TopicManagerLogger = noopLogger,
     globalState?: GlobalStateStore,
+    private readonly onChatMigrated?: (newChatId: number) => void | Promise<void>,
   ) {
     this._machineId = machineId;
     this.globalState = globalState;
@@ -46,6 +48,11 @@ export class TopicManager {
 
   get machineId(): string {
     return this._machineId;
+  }
+
+  /** Current chat ID — updated automatically when the group migrates to a supergroup. */
+  get currentChatId(): number | string {
+    return this.chatId;
   }
 
   get activeSessions(): string[] {
@@ -80,15 +87,19 @@ export class TopicManager {
 
     this.syncing.add(sessionId);
     try {
-      this.topicCounter++;
+      // Name from the prospective count; only commit the counter once the topic
+      // is actually created, so a failed attempt doesn't burn a number (which
+      // otherwise produces "Project #2 #3 #4…" spam on repeated failed clicks).
+      const nextCount = this.topicCounter + 1;
       const topicName =
-        this.topicCounter === 1
+        nextCount === 1
           ? label.slice(0, TELEGRAM_TOPIC_NAME_LIMIT)
-          : `${label} #${this.topicCounter}`.slice(0, TELEGRAM_TOPIC_NAME_LIMIT);
+          : `${label} #${nextCount}`.slice(0, TELEGRAM_TOPIC_NAME_LIMIT);
 
       this.logger.info(`Creating forum topic "${topicName}" for session ${sessionId}`);
-      const topic: ForumTopic = await this.api.createForumTopic(this.chatId, topicName);
+      const topic: ForumTopic = await this.createTopicWithMigration(topicName);
       const threadId = topic.message_thread_id;
+      this.topicCounter = nextCount;
 
       this.sessionToTopic.set(sessionId, threadId);
       this.topicToSession.set(threadId, sessionId);
@@ -98,6 +109,32 @@ export class TopicManager {
       return threadId;
     } finally {
       this.syncing.delete(sessionId);
+    }
+  }
+
+  /**
+   * Creates a forum topic, self-healing if the group has been upgraded to a
+   * supergroup. Telegram returns the new chat ID in the migration error; we
+   * adopt it, notify the host (so it can persist the ID and update the bridge),
+   * and retry once against the new ID. A second failure propagates normally.
+   */
+  private async createTopicWithMigration(topicName: string): Promise<ForumTopic> {
+    try {
+      return await this.api.createForumTopic(this.chatId, topicName);
+    } catch (err: unknown) {
+      if (!(err instanceof TelegramMigrationError)) throw err;
+
+      this.logger.warn(
+        `Chat ${this.chatId} was upgraded to a supergroup — switching to ${err.migrateToChatId} and retrying`,
+      );
+      this.chatId = err.migrateToChatId;
+      try {
+        await this.onChatMigrated?.(err.migrateToChatId);
+      } catch (cbErr: unknown) {
+        const msg = cbErr instanceof Error ? cbErr.message : String(cbErr);
+        this.logger.warn(`onChatMigrated callback failed (continuing with retry): ${msg}`);
+      }
+      return await this.api.createForumTopic(this.chatId, topicName);
     }
   }
 

--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -65,7 +65,28 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
       info: (msg: string) => this.output.appendLine(`[telegram-topic] ${msg}`),
       warn: (msg: string) => this.output.appendLine(`[telegram-topic] WARN: ${msg}`),
     };
-    this.topicManager = new TopicManager(api, telegramConfig.chatId, vscode.env.machineId, logger, this.context.globalState);
+    this.topicManager = new TopicManager(
+      api,
+      telegramConfig.chatId,
+      vscode.env.machineId,
+      logger,
+      this.context.globalState,
+      async (newChatId: number) => {
+        // The group was upgraded to a supergroup. Point the bridge at the new
+        // ID and persist it so future sessions start from the valid supergroup.
+        this.bridge?.setChatId(newChatId);
+        try {
+          const cfg = vscode.workspace.getConfiguration("gsd");
+          await cfg.update("telegramGroupId", newChatId, vscode.ConfigurationTarget.Global);
+          this.output.appendLine(
+            `[telegram-sync] Group upgraded to supergroup — saved new group ID ${newChatId}`,
+          );
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.output.appendLine(`[telegram-sync] Failed to persist migrated group ID: ${msg}`);
+        }
+      },
+    );
 
     const bridgeLogger: TopicManagerLogger = {
       info: (msg: string) => this.output.appendLine(`[telegram-bridge] ${msg}`),


### PR DESCRIPTION
@
## Problem

When a Telegram group is upgraded to a supergroup, its `chat_id` changes (supergroups gain the `-100…` prefix). The old ID becomes permanently invalid and every API call against it returns `400 Bad Request: group chat was upgraded to a supergroup chat`. Our API client read only `retry_after` from the error `parameters` and discarded `migrate_to_chat_id`, so sync looped forever against the dead ID — the sync button never latched and no topics were created.

## Fix (self-healing)

- **`api.ts`** — surface `migrate_to_chat_id` in the response type and throw a typed `TelegramMigrationError` carrying the new chat ID instead of an opaque 400 string.
- **`topicManager.ts`** — `createForumTopic` adopts the new ID on a migration error, fires an `onChatMigrated` callback, and retries once. Fixed the counter so a failed attempt no longer burns a topic number (the `#22…#25` escalation in the report).
- **`bridge.ts`** — `setChatId()` so the live bridge follows the migration for outbound messages.
- **`webview-provider.ts`** — wire the callback to update the bridge and persist the new `telegramGroupId` to settings, so future sessions start clean.

## Verification

- `tsc --noEmit` clean
- Full suite: 1402 tests pass (66 files), incl. 5 new tests (migration error, self-heal + retry, retry-also-fails, counter fix)
- eslint clean on changed files

Bumped to 0.3.69 with changelog entry.
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telegram supergroup upgrades now automatically detect, update, and persist chat ID changes, with automatic synchronisation retry to ensure seamless migration.
  * Topic creation failures no longer consume topic numbers, preventing escalating topic naming issues and improving synchronisation reliability during repeated failed sync attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kile-Thomson/Rokket-GSD/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->