### PR TITLE
Telegram: clear 'enable Topics' guidance and owner-ID auto-detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Rokket GSD will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.72] — 2026-05-31
+
+### Added
+- **Telegram owner ID auto-detect** — setup now captures your Telegram user ID from the message you send during group detection, and prompts for it when you enter the group ID manually. You can send commands back to GSD from Telegram straight away, without a separate /whoami step.
+
+### Fixed
+- **Clear guidance when Topics aren't enabled** — if your supergroup doesn't have Topics turned on, the sync button now explains how to enable them instead of silently failing with a raw API error.
+
 ## [0.3.69] — 2026-05-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rokket-gsd",
-	"version": "0.3.69",
+	"version": "0.3.72",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rokket-gsd",
-			"version": "0.3.69",
+			"version": "0.3.72",
 			"license": "MIT",
 			"dependencies": {
 				"dompurify": "^3.4.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rokket-gsd",
 	"displayName": "GSD Pi Premium GUI — RokketGSD",
 	"description": "The GSD Pi (OpenGSD) VS Code extension — AI coding agent with chat UI, multi-model support, 40+ tool visualizations, Telegram voice relay, parallel workers, and workflow automation. Also compatible with GSD V2.",
-	"version": "0.3.71",
+	"version": "0.3.72",
 	"publisher": "rokketek",
 	"license": "MIT",
 	"repository": {

--- a/src/extension/telegram/api.test.ts
+++ b/src/extension/telegram/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { TelegramApi, redactToken, TelegramMigrationError } from "./api";
+import { TelegramApi, redactToken, TelegramMigrationError, TelegramNotForumError } from "./api";
 
 const TOKEN = "123456:ABC-DEF";
 
@@ -196,6 +196,19 @@ describe("TelegramApi", () => {
       await expect(api.createForumTopic(-100, "Test")).rejects.toBeInstanceOf(
         TelegramMigrationError,
       );
+    });
+
+    it("throws TelegramNotForumError when the supergroup has no Topics enabled", async () => {
+      globalThis.fetch = mockFetch(
+        { ok: false, description: "Bad Request: the chat is not a forum" },
+        400,
+      );
+
+      const err = await api.createForumTopic(-100, "Test").catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(TelegramNotForumError);
+      const forumErr = err as TelegramNotForumError;
+      expect(forumErr.status).toBe(400);
+      expect(forumErr.description).toContain("not a forum");
     });
 
     it("TelegramMigrationError exposes migrateToChatId, status, and description", async () => {

--- a/src/extension/telegram/api.ts
+++ b/src/extension/telegram/api.ts
@@ -101,6 +101,25 @@ export class TelegramMigrationError extends Error {
   }
 }
 
+/**
+ * Thrown when a forum method (e.g. createForumTopic) targets a supergroup that
+ * does not have Topics enabled. Telegram returns `400 Bad Request: the chat is
+ * not a forum`. The fix is a one-time toggle in the group settings, not a
+ * re-setup, so callers should surface an actionable "enable Topics" message
+ * rather than the raw 400. Carries no token, so it is safe to log unredacted.
+ */
+export class TelegramNotForumError extends Error {
+  constructor(
+    readonly status: number,
+    readonly description: string,
+  ) {
+    super(
+      "Telegram supergroup does not have Topics enabled — enable Topics to create forum topics",
+    );
+    this.name = "TelegramNotForumError";
+  }
+}
+
 export class TelegramApi {
   private readonly baseUrl: string;
 
@@ -143,6 +162,9 @@ export class TelegramApi {
       const migrateTo = data.parameters?.migrate_to_chat_id;
       if (migrateTo != null) {
         throw new TelegramMigrationError(migrateTo, response.status, desc);
+      }
+      if (/not a forum/i.test(desc)) {
+        throw new TelegramNotForumError(response.status, desc);
       }
       const retryHint =
         data.parameters?.retry_after != null

--- a/src/extension/telegram/setup.test.ts
+++ b/src/extension/telegram/setup.test.ts
@@ -171,6 +171,27 @@ describe("runTelegramSetup", () => {
     });
   });
 
+  it("captures the owner ID from the detection message sender", async () => {
+    inputBoxQueue = [TOKEN];
+    mockGetMe.mockResolvedValue(BOT_USER);
+    mockGetUpdates.mockResolvedValue([
+      {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          from: { id: 5550123, is_bot: false, first_name: "Operator" },
+          chat: { id: CHAT.id, title: CHAT.title, type: "supergroup" },
+        },
+      },
+    ]);
+    mockGetChatMember.mockResolvedValue({ status: "administrator", user: BOT_USER });
+    mockSendMessage.mockResolvedValue({ message_id: 2, chat: CHAT });
+
+    await runTelegramSetup(mockContext());
+
+    expect(savedConfig?.ownerId).toBe(5550123);
+  });
+
   it("aborts when user cancels step 1 modal", async () => {
     mockShowInfoMessage.mockResolvedValueOnce(undefined);
 
@@ -235,10 +256,11 @@ describe("runTelegramSetup", () => {
     mockGetChatMember.mockResolvedValue({ status: "administrator", user: BOT_USER });
     mockSendMessage.mockResolvedValue({ message_id: 2, chat: CHAT });
 
-    // First showInputBox returns token, second returns manual group ID
+    // showInputBox: 1) token, 2) manual group ID, 3) manual owner ID
     mockShowInputBox
       .mockResolvedValueOnce(TOKEN)
-      .mockResolvedValueOnce(String(CHAT.id));
+      .mockResolvedValueOnce(String(CHAT.id))
+      .mockResolvedValueOnce("7770456");
 
     let callCount = 0;
     mockWithProgress.mockImplementation(async (_opts: unknown, task: (p: unknown, c: vscode.CancellationToken) => Promise<unknown>) => {
@@ -252,9 +274,10 @@ describe("runTelegramSetup", () => {
 
     await runTelegramSetup(mockContext());
 
-    expect(mockShowInputBox).toHaveBeenCalledTimes(2);
+    expect(mockShowInputBox).toHaveBeenCalledTimes(3);
     expect(savedConfig).not.toBeNull();
     expect(savedConfig?.chatId).toBe(CHAT.id);
+    expect(savedConfig?.ownerId).toBe(7770456);
   });
 
   it("offers voice setup after completion", async () => {

--- a/src/extension/telegram/setup.ts
+++ b/src/extension/telegram/setup.ts
@@ -122,6 +122,10 @@ export async function runTelegramSetup(context: vscode.ExtensionContext): Promis
               return {
                 chatId: update.message.chat.id,
                 chatTitle: update.message.chat.title ?? "",
+                // The person who sent the detection message is the operator —
+                // capture their user ID as the owner so they can send commands
+                // back to GSD without a separate /whoami round trip.
+                ownerId: update.message.from?.id ?? 0,
               };
             }
           }
@@ -157,12 +161,25 @@ export async function runTelegramSetup(context: vscode.ExtensionContext): Promis
       return;
     }
 
-    await finishSetup(context, output, api, token, me, parsed, "");
+    // No detection message means no sender to read the owner ID from — ask for
+    // it directly. Optional: blank skips and they can set it later via /whoami.
+    const manualOwner = await vscode.window.showInputBox({
+      title: "Your Telegram user ID (optional)",
+      prompt:
+        "Enter your Telegram user ID so you can send commands back to GSD from Telegram. " +
+        "Leave blank to skip — you can set it later by sending /whoami in your group. " +
+        "(Tip: @RawDataBot or sending /whoami shows your user ID.)",
+      placeHolder: "123456789",
+      ignoreFocusOut: true,
+    });
+    const manualOwnerId = manualOwner ? parseInt(manualOwner, 10) : 0;
+
+    await finishSetup(context, output, api, token, me, parsed, "", Number.isNaN(manualOwnerId) ? 0 : manualOwnerId);
     return;
   }
 
   output.appendLine(`[telegram-setup] Detected chat: "${chatResult.chatTitle}" (${chatResult.chatId})`);
-  await finishSetup(context, output, api, token, me, chatResult.chatId, chatResult.chatTitle);
+  await finishSetup(context, output, api, token, me, chatResult.chatId, chatResult.chatTitle, chatResult.ownerId);
 }
 
 async function finishSetup(
@@ -173,6 +190,7 @@ async function finishSetup(
   me: { id: number; username?: string; first_name: string },
   chatId: number,
   chatTitle: string,
+  ownerId: number,
 ): Promise<void> {
   // --- Step 3: Verify & Save ---
   output.appendLine("[telegram-setup] Verifying bot admin permissions...");
@@ -212,9 +230,12 @@ async function finishSetup(
     chatId,
     chatTitle,
     streamingGranularity: "throttled",
-    ownerId: 0,
+    ownerId,
     projectSearchDirs: [],
   };
+  if (ownerId) {
+    output.appendLine(`[telegram-setup] Captured owner ID ${ownerId}`);
+  }
   await saveTelegramConfig(
     context.secrets,
     config,

--- a/src/extension/webview-provider.ts
+++ b/src/extension/webview-provider.ts
@@ -15,7 +15,7 @@ import { handleRpcEvent, type RpcEventContext } from "./rpc-events";
 import type { FileOpsContext } from "./file-ops";
 import { handleWebviewMessage, type MessageDispatchContext } from "./message-dispatch";
 import { TopicManager, type TopicManagerLogger } from "./telegram/topicManager";
-import { TelegramApi, redactToken } from "./telegram/api";
+import { TelegramApi, redactToken, TelegramNotForumError } from "./telegram/api";
 import { loadTelegramConfig } from "./telegram/config";
 import { TelegramBridge } from "./telegram/bridge";
 import { TranscriptionError } from "./openai/transcribe";
@@ -195,6 +195,19 @@ export class GsdWebviewProvider implements vscode.WebviewViewProvider {
         }
       }
     } catch (err: unknown) {
+      // Topics aren't enabled on the supergroup — actionable, not a re-setup.
+      // Surface a clear instruction instead of swallowing the raw 400 (the
+      // sync button stays unlatched, which is correct since no topic exists).
+      if (err instanceof TelegramNotForumError) {
+        this.output.appendLine(
+          "[telegram-sync] Group is not a forum — Topics not enabled; prompting user to enable Topics",
+        );
+        vscode.window.showWarningMessage(
+          'Telegram sync couldn’t create a topic because your group doesn’t have Topics enabled. ' +
+            'Open your Telegram group → Edit → turn on "Topics", then click the sync button again.',
+        );
+        return;
+      }
       const msg = err instanceof Error ? err.message : String(err);
       const config = vscode.workspace.getConfiguration("gsd");
       const telegramConfig = await loadTelegramConfig(this.context.secrets, config);


### PR DESCRIPTION
Two follow-up refinements to the Telegram supergroup-migration fix shipped in 0.3.71.

## Changes

**1 — Clear "enable Topics" message instead of a raw 400** (`api.ts`, `webview-provider.ts`)
- New typed `TelegramNotForumError`: recognizes Telegram's `400 ... the chat is not a forum` and throws it typed instead of an opaque string.
- The sync-toggle handler catches it and shows a clear instruction to enable Topics, then click sync again. Previously this error was only logged, so the button silently failed to latch. This is the post-migration retry case: the new supergroup ID is already saved, so the user only needs the one toggle.

**2 — Owner-ID auto-detect in setup** (`setup.ts`)
- During group detection, captures the sender's Telegram user ID (`message.from.id`) and persists it, removing the separate `/whoami` step for the common path.
- On the manual-ID fallback, prompts for the owner ID with a blank-to-skip option and a `/whoami` hint.

## Verification
- `tsc --noEmit` clean
- `eslint` clean on all changed files
- Full suite: 1404 tests pass (66 files), +3 new tests covering typed `TelegramNotForumError`, owner-ID captured from the detection sender, and owner-ID via manual entry.

Bumped to 0.3.72 with a changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Telegram group owner ID is now automatically detected during setup, with a manual entry option available if auto-detection times out.
* Improved error handling for Telegram Topics—users receive clear instructions on enabling Topics instead of technical API errors.

**Chores**
* Version updated to 0.3.72.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kile-Thomson/Rokket-GSD/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->