### PR TITLE
Fix live workflow card stranded at top after sidebar reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ scripts/*-results.json
 .dropboxignore
 *conflicted copy*
 
-# ── GSD baseline (auto-generated) ──
+# ── GSD baseline – build output ──
 .gsd
 .gsd-id
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,16 @@ scripts/*-results.json
 .gsd-id
 dist/
 *.tsbuildinfo
+
+# ── GSD baseline (auto-generated) ──
+nul.*
+con
+con.*
+prn
+prn.*
+aux
+aux.*
+com[1-9]
+com[1-9].*
+lpt[1-9]
+lpt[1-9].*

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ scripts/*-results.json
 dist/
 *.tsbuildinfo
 
-# ── GSD baseline (auto-generated) ──
+# ── GSD baseline – DOS device names ──
 nul.*
 con
 con.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Rokket GSD will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.81] — 2026-06-01
+
+### Added
+- **Live workflow visibility** — when the agent launches a Claude Code workflow that fans out parallel sub-agents, a live card now appears **inline in the conversation** the moment the run starts. It pins above the launching turn and ticks each sub-agent running → done in real time, so you can see what's running and what it's doing without leaving the editor — no `/workflows` command, no DevTools. The card stays in the transcript as a record once the run finishes, showing per-agent token usage, tool-call counts, and duration.
+
+### Fixed
+- **Progress appears during the run, not just at turn end** — workflow progress is read directly from the run's on-disk journal, so the card updates live throughout the background run instead of only when the turn settles.
+- **No more false "hung" labels** — a completed workflow whose activity naturally goes quiet now reads as **Done**; the "may be hung" warning is reserved for a run with a sub-agent still mid-flight and no further activity.
+- **Accurate per-agent token counts** — counts now show real variance (e.g. `14.6k` / `14.7k`) instead of collapsing to a flat figure.
+- **Workflow tool block title** — now reads the workflow's name (e.g. `render-demo`) instead of dumping the raw script source.
+- **Resilient across reloads** — live and completed cards survive hiding and re-showing the sidebar, are retracted cleanly when the GSD process exits, and no longer leak between conversations.
+
+## [0.3.75] — 2026-06-01
+
+### Fixed
+- **Workflow progress stays visible during the run** — a self-healing re-attach keeps the live workflow card in place if the conversation view is rebuilt mid-turn, instead of waiting for the turn to settle.
+- **False "hung" warning removed** — a quiet workflow journal with nothing in flight is now reported as Done rather than ageing into a "may be hung" state after the turn is over.
+
+## [0.3.74] — 2026-06-01
+
+### Added
+- **Sub-agent usage on completion** — completed sub-agent (`Agent`) cards now show tokens, tool-call count, and duration, fixing a parser gap that previously dropped the token count for single sub-agents.
+- **Long-running cue** — a sub-agent that runs past two minutes gets a subtle amber highlight and coloured elapsed timer to draw your eye, without overclaiming a stall it can't detect.
+
+## [0.3.73] — 2026-06-01
+
+### Added
+- **Live progress for background workflows** — Claude Code workflow runs surface their plan (name, phases, and the agent list) and live progress in the chat window, with a completion table summarising each agent's usage.
+
 ## [0.3.72] — 2026-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Watch fan-out workflows tick agent-by-agent, inline, as they run
 🎙️ **Voice Input**<br>
 Hold-to-record with waveform viz; OpenAI, Azure, or xAI transcription
 
-🧪 **1472+ Tests**<br>
+🧪 **1473+ Tests**<br>
 CI enforced on every push
 
 </td>
@@ -511,7 +511,7 @@ Built to handle real-world agent sessions that run for hours:
 - **GSD Process** — the full [GSD Pi](https://github.com/OpenGSD/gsd-pi) agent running via JSON-RPC over stdin/stdout. Each session gets its own process.
 - **Telegram Bridge** — poller, coordinator, IPC, topic manager, and message formatter. Voice messages transcribed via OpenAI Whisper; photos forwarded as image attachments.
 
-The extension ships as a `.vsix` with no runtime dependencies beyond VS Code and the `gsd` CLI ([GSD Pi](https://github.com/OpenGSD/gsd-pi) or GSD V2). 1472 tests across 73 files.
+The extension ships as a `.vsix` with no runtime dependencies beyond VS Code and the `gsd` CLI ([GSD Pi](https://github.com/OpenGSD/gsd-pi) or GSD V2). 1473 tests across 73 files.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.3.63-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.3.81-blue" alt="Version" />
   <img src="https://img.shields.io/badge/VS%20Code-1.94%2B-blue" alt="VS Code" />
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License" />
   <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey" alt="Platform" />
@@ -83,13 +83,16 @@ Warning toast when workers cross 80% of ceiling
 🛡️ **Process Resilience**<br>
 Built for multi-hour sessions with crash recovery
 
-📡 **Telegram Relay**<br>
-Stream conversations to Telegram with voice transcription
+📡 **Telegram Remote Control**<br>
+Drive your agent from your phone — voice, photos, and per-session threads
+
+🌀 **Live Workflow Visibility**<br>
+Watch fan-out workflows tick agent-by-agent, inline, as they run
 
 🎙️ **Voice Input**<br>
 Hold-to-record with waveform viz; OpenAI, Azure, or xAI transcription
 
-🧪 **1397+ Tests**<br>
+🧪 **1472+ Tests**<br>
 CI enforced on every push
 
 </td>
@@ -334,6 +337,17 @@ Type `/` to open the command palette with 59+ commands:
 - **Duration tracking** on every completed tool call
 - **Server-side tool indicators** — compact inline cards for Anthropic's native server-side tools (web search, code execution) showing tool name, search query, spinner while running, and result count on completion
 
+### 🌀 Live Workflow Visibility
+
+When the agent launches a Claude Code workflow that fans out parallel sub-agents, you no longer wait until the turn ends to find out what happened:
+
+- **Inline live card** — a workflow card appears in the conversation the moment the run starts writing, pinned above the launching turn — no `/workflows` command, no DevTools
+- **Agent-by-agent progress** — each sub-agent's label and phase tick from running → done in real time as the run proceeds, fed by watching the workflow's on-disk journal directly (so it updates mid-turn, not just at completion)
+- **Honest hang detection** — a run with a sub-agent still mid-flight and no further activity is flagged; a run that simply finished and went quiet reads as Done, not falsely "hung"
+- **Completion summary** — the card persists in the transcript as a record, showing real per-agent token usage, tool-call counts, and duration
+- **Robust** — survives sidebar hide/show, retracts cleanly on process exit, and never leaks between conversations
+- **Opt-in diagnostics** — `gsd.workflowDiagnostics` surfaces an on-screen panel for troubleshooting live-update delivery
+
 ### ⚡ Auto-Mode Progress
 
 - **Live progress widget** sticky above the input showing current task, phase, progress bars, elapsed time, cost, and active model
@@ -372,15 +386,19 @@ Type `/` to open the command palette with 59+ commands:
 - **Provider fallback alerts** via toast when GSD auto-switches models due to rate limits, and again when the original provider recovers
 - **Crash recovery** with restart button, exit code diagnostics, and full state cleanup
 
-### 📡 Telegram Relay
+### 📡 Telegram Remote Control
 
-- **Stream conversations to Telegram** — relay assistant messages to a Telegram group in real time
-- **Setup wizard** via `/telegram` or the command palette with guided Bot Token → Group ID → Chat Title flow
-- **Voice message transcription** — Telegram voice messages are transcribed via OpenAI Whisper and injected as user prompts
-- **Photo support** — images sent in Telegram are forwarded to the agent as attachments
-- **Topic-based threading** — each session creates a Telegram topic for organized conversations
-- **Streaming granularity control** — configure as `off`, `throttled`, or `final-only` in settings
-- **Secure credential storage** — Bot Token and OpenAI API key stored in VS Code's `SecretStorage`, never in source files
+**Run your agent from anywhere.** Connect a Telegram bot once and your editor session becomes a two-way remote: read what the agent is doing, reply with new instructions, and kick off whole projects — all from your phone, away from the desk. Long auto-mode runs no longer pin you to the keyboard.
+
+- **Two-way control, not just a feed** — assistant responses stream to your Telegram group in real time, and anything you send back is injected straight into the live session as a prompt. Steer, answer questions, or redirect the agent without touching the keyboard.
+- **Talk to it** — record a Telegram voice message and it's transcribed (OpenAI Whisper) and sent as a prompt, so you can brief the agent hands-free.
+- **Send pictures** — photos shared in the chat are forwarded to the agent as image attachments (screenshots, mockups, error dialogs).
+- **Launch projects by name** — message something like *"launch rokketdocs"* from the general chat and the bot finds the project across your configured directories, opens it in VS Code, and wires up the relay automatically. Numbered picker resolves multiple matches.
+- **A thread per session** — each conversation gets its own Telegram topic, so parallel projects stay cleanly separated instead of colliding in one feed.
+- **Owner-locked commands** — launch and control commands are restricted to your own Telegram user ID (auto-detected during setup), so a shared group can't drive your machine.
+- **Resilient by design** — automatically follows a group when it's upgraded to a supergroup (new chat ID), and gives clear, actionable guidance when forum Topics aren't enabled instead of failing silently.
+- **Tunable verbosity** — choose `off`, `throttled`, or `final-only` streaming so the chat stays useful without becoming noise.
+- **Guided, secure setup** — the `/telegram` wizard walks Bot Token → group detection → owner ID → done. The bot token and transcription API key live in VS Code's `SecretStorage`, never in config files or source.
 
 ### 🎨 VS Code Integration
 
@@ -435,10 +453,16 @@ Type `/` to open the command palette with 59+ commands:
 | `gsd.preferredLocation` | `"panel"` | Default open location: `"sidebar"` or `"panel"` |
 | `gsd.autoUpdate` | `true` | Check for new versions on GitHub Releases |
 | `gsd.githubToken` | `""` | GitHub token for update checks (also reads `GH_TOKEN` / `GITHUB_TOKEN` env vars) |
-| `gsd.telegramGroupId` | `0` | Telegram group ID for the relay |
-| `gsd.telegramChatTitle` | `""` | Telegram group chat title |
-| `gsd.telegramBotUsername` | `""` | Telegram bot username |
+| `gsd.workflowLivePanel` | `true` | Show live Claude Code workflow progress inline as it happens |
+| `gsd.workflowDiagnostics` | `false` | On-screen diagnostic overlay for workflow progress delivery (troubleshooting) |
+| `gsd.telegramGroupId` | `0` | Telegram group ID for the relay (set by setup) |
+| `gsd.telegramChatTitle` | `""` | Telegram group chat title (set by setup) |
+| `gsd.telegramBotUsername` | `""` | Telegram bot username (set by setup) |
+| `gsd.telegramOwnerId` | `0` | Your Telegram user ID — only this user can trigger launch commands (auto-detected at setup) |
+| `gsd.telegramProjectDirs` | `[]` | Directories searched when launching projects from Telegram general chat |
 | `gsd.telegramStreamingGranularity` | `"throttled"` | Streaming mode: `off`, `throttled`, or `final-only` |
+| `gsd.voiceTranscriptionProvider` | `"openai"` | Voice-to-text provider: `openai`, `azure`, or `xai` |
+| `gsd.azureSpeechRegion` | `"eastus"` | Azure region for Speech Services (when provider is `azure`) |
 
 ---
 
@@ -487,7 +511,7 @@ Built to handle real-world agent sessions that run for hours:
 - **GSD Process** — the full [GSD Pi](https://github.com/OpenGSD/gsd-pi) agent running via JSON-RPC over stdin/stdout. Each session gets its own process.
 - **Telegram Bridge** — poller, coordinator, IPC, topic manager, and message formatter. Voice messages transcribed via OpenAI Whisper; photos forwarded as image attachments.
 
-The extension ships as a `.vsix` with no runtime dependencies beyond VS Code and the `gsd` CLI ([GSD Pi](https://github.com/OpenGSD/gsd-pi) or GSD V2). 1397 tests across 66 files.
+The extension ships as a `.vsix` with no runtime dependencies beyond VS Code and the `gsd` CLI ([GSD Pi](https://github.com/OpenGSD/gsd-pi) or GSD V2). 1472 tests across 73 files.
 
 ---
 

--- a/src/webview/__tests__/workflow-live.test.ts
+++ b/src/webview/__tests__/workflow-live.test.ts
@@ -133,6 +133,35 @@ describe("workflow-live inline conversation card", () => {
     expect(card()).toBeNull();
   });
 
+  it("repositions a card that landed before entries rendered (rebind race)", () => {
+    // Simulate the rebind race: update() fires before history renders, so the card
+    // is appended to an empty container (no .gsd-entry yet). Then history renders.
+    update(snapshot({ status: "running" }));
+    const container = document.getElementById("messagesContainer")!;
+    expect(card()).not.toBeNull();
+    // Card is currently at position 0 (appended to empty container).
+    expect(container.children[0]).toBe(card());
+
+    // Now history renders — entries appear after the card.
+    const entry1 = document.createElement("div");
+    entry1.className = "gsd-entry";
+    entry1.dataset.entryId = "user";
+    container.appendChild(entry1);
+    const entry2 = document.createElement("div");
+    entry2.className = "gsd-entry";
+    entry2.dataset.entryId = "assistant";
+    container.appendChild(entry2);
+    // Card is still at position 0, before both entries — wrong.
+    expect(container.children[0]).toBe(card());
+
+    // The heartbeat repositions it above the last entry.
+    vi.advanceTimersByTime(1000);
+    const kids = Array.from(container.children);
+    const cardIdx = kids.indexOf(card()!);
+    const assistantIdx = kids.indexOf(entry2);
+    expect(cardIdx).toBe(assistantIdx - 1);
+  });
+
   it("does not run a heartbeat when the only run is already terminal", () => {
     update(snapshot({ status: "completed", runningAgentCount: 0, doneAgentCount: 2 }));
     document.getElementById("messagesContainer")!.innerHTML = "";

--- a/src/webview/workflow-live.ts
+++ b/src/webview/workflow-live.ts
@@ -52,21 +52,24 @@ function findCard(runId: string): HTMLElement | null {
 }
 
 /**
- * Place a fresh card just *above* the most recent conversation entry — the
- * assistant turn that launched the workflow — so it reads as a header for that
- * turn rather than trailing underneath its text. Falls back to appending when no
- * entry has rendered yet (defensive; the launching turn always exists by the time
- * a run surfaces). Insertion happens once, at create time; an existing card is
- * never moved, so later turns don't shuffle a settled record.
+ * Place a card just *above* the most recent conversation entry — the assistant
+ * turn that launched the workflow — so it reads as a header for that turn rather
+ * than trailing underneath its text. No-ops if the card is already in the correct
+ * position. Falls back to appending when no entry has rendered yet (the heartbeat
+ * will reposition it once entries exist).
  */
 function insertCardInto(container: HTMLElement, card: HTMLElement): void {
   const entries = container.querySelectorAll<HTMLElement>(".gsd-entry");
   const anchor = entries.length ? entries[entries.length - 1] : null;
-  if (anchor) container.insertBefore(card, anchor);
-  else container.appendChild(card);
+  if (anchor) {
+    if (card.parentElement === container && card.nextSibling === anchor) return; // already correct
+    container.insertBefore(card, anchor);
+  } else {
+    container.appendChild(card);
+  }
 }
 
-/** Find this run's card, creating and inserting it above the launching turn if absent. */
+/** Find this run's card, creating and inserting it if absent. */
 function ensureCard(runId: string): HTMLElement {
   let card = findCard(runId);
   if (!card) {
@@ -122,22 +125,31 @@ function stopHeartbeat(): void {
 }
 
 /**
- * Re-attach any live card that has gone missing from the conversation DOM.
+ * Re-attach or reposition any live card that was dropped or misplaced.
  *
  * Cards live in `#messagesContainer`, which streaming/finalization append to
  * rather than rebuild, so a card placed there normally persists across the turn
- * ending. The
- * heartbeat is cheap insurance: if some rebuild does drop a still-live run's
- * card, it reappears within a second instead of waiting on the next watcher poll.
- * Present cards are left untouched (no flicker). Terminal cards are not tracked
- * here, so they're never resurrected. The timer stops once nothing is live.
+ * ending. After a sidebar rebind the webview HTML is rebuilt before conversation
+ * history re-renders, so a replayed card can land before any `.gsd-entry` exists
+ * and end up stranded at the top of the container. The heartbeat corrects both
+ * cases: missing cards are re-created; mispositioned cards (nextSibling is not
+ * the last entry) are moved. Terminal cards are not tracked here.
  */
 function heartbeatTick(): void {
   let anyLive = false;
+  const container = messagesEl();
   for (const [runId, data] of latest) {
     if (!isLive(data.status)) continue;
     anyLive = true;
-    if (!findCard(runId)) paint(ensureCard(runId), data);
+    if (!container) continue;
+    const existing = findCard(runId);
+    if (!existing) {
+      const card = ensureCard(runId);
+      if (card) paint(card, data);
+    } else {
+      // Reposition if the card landed before entries rendered (rebind race).
+      insertCardInto(container, existing);
+    }
   }
   if (!anyLive) stopHeartbeat();
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `rebindWebview` replays a workflow snapshot before conversation history renders, causing `ensureCard` to append the card to an empty `#messagesContainer`. History then renders *after* the card, stranding it at the top of the conversation.
- `insertCardInto` is now idempotent — no-ops if the card is already in the correct position, appends as fallback when no entries exist yet.
- `heartbeatTick` now repositions an existing card that isn't directly before the last `.gsd-entry`, in addition to re-creating a missing card.

## Test plan

- [ ] Verified 1473 tests pass (73 test files, all green)
- [ ] New test: "repositions a card that landed before entries rendered (rebind race)" covers the exact failure scenario
- [ ] Open a session with active workflows, reload the sidebar — card should appear at the correct position in conversation history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live Workflow Visibility for inline, real-time Claude Code fan-out progress tracking.
  * Telegram Remote Control with two-way control, voice transcription, photo forwarding and project launching.

* **Bug Fixes**
  * Improved live card positioning and lifecycle in conversation history.
  * More accurate live progress, hang-detection fixes and per-agent summaries; improved resilience across reloads.

* **Documentation**
  * Version updated to 0.3.81; expanded README and configuration guidance.

* **Tests**
  * Added coverage for live card repositioning scenarios.

* **Chores**
  * Updated repository ignore entries to avoid matching Windows device name patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->