### PR TITLE
fix(webview): correct welcome splash to "Git Ship Done"

### DIFF
--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -233,7 +233,7 @@ root.innerHTML = `
 ╚██████╔╝███████║██████╔╝
  ╚═════╝ ╚══════╝╚═════╝</pre>
         </div>
-        <div class="gsd-welcome-title">Get Shit Done</div>
+        <div class="gsd-welcome-title">Git Ship Done</div>
         <div class="gsd-welcome-sub" id="welcomeProcess">Initializing...</div>
         <div class="gsd-welcome-model" id="welcomeModel"></div>
         <div class="gsd-welcome-hints gsd-hidden" id="welcomeHints"></div>


### PR DESCRIPTION
## What

Updates the extension welcome/splash screen title from the legacy **"Get Shit Done"** to **"Git Ship Done"**, matching the GSD-Pi 1.3.0 rebrand.

## Why

GSD-Pi 1.3.0 ships a new product wordmark. Rokket GSD re-implements its own webview shell, so the splash title is one of the few surfaces that can drift from upstream branding — and it had. This realigns it.

## Scope

- `src/webview/index.ts:236` — one-line title string change.
- ASCII wordmark intentionally left as the bare "GSD" block (this product is *Rokket GSD*, not GSD-Pi, so the `─ Pi` suffix from upstream is not adopted).
- Uncompiled TS; CI build/package will ship it.

## Notes

The rest of the 1.3.0 changelog (engine/workflow/db internals) flows through automatically because Rokket spawns the user's installed `gsd` as a child process — no code change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated welcome screen title text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->