### PR TITLE
fix(dashboard): support gsd-pi v1.4.0 flat-phase layout

### DIFF
--- a/src/extension/dashboard-parser.test.ts
+++ b/src/extension/dashboard-parser.test.ts
@@ -262,6 +262,96 @@ Execute T03 for S02
     expect(result!.progress.milestones).toEqual({ done: 1, total: 2 });
   });
 
+  // ── gsd-pi 1.4.0 flat-phase layout ────────────────────────────
+
+  it("finds roadmap in flat-phase phases/{MID}-{slug}/ layout", async () => {
+    const gsdDir = path.join(tmpDir, ".gsd");
+    const phaseDir = path.join(gsdDir, "phases", "M001-my-feature");
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(gsdDir, "STATE.md"), "");
+    fs.writeFileSync(
+      path.join(phaseDir, "M001-ROADMAP.md"),
+      `- [x] **S01: Done slice** \`risk:low\`
+- [ ] **S02: Active slice** \`risk:high\`
+`
+    );
+
+    mockParseWorkflow.mockResolvedValue({
+      milestone: { id: "M001", title: "my feature" },
+      slice: { id: "S02", title: "Active slice" },
+      task: null,
+      phase: "build",
+      autoMode: null,
+    });
+
+    const result = await buildDashboardData(tmpDir);
+
+    expect(result!.hasMilestone).toBe(true);
+    expect(result!.slices).toHaveLength(2);
+    expect(result!.slices[0]).toMatchObject({ id: "S01", done: true });
+    expect(result!.slices[1]).toMatchObject({ id: "S02", done: false, active: true });
+  });
+
+  it("finds slice plan in flat-phase layout (plan in phase dir, not slices/ subdir)", async () => {
+    const gsdDir = path.join(tmpDir, ".gsd");
+    const phaseDir = path.join(gsdDir, "phases", "M001-my-feature");
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(gsdDir, "STATE.md"), "");
+    fs.writeFileSync(
+      path.join(phaseDir, "M001-ROADMAP.md"),
+      `- [ ] **S01: Do things** \`risk:low\`\n`
+    );
+    fs.writeFileSync(
+      path.join(phaseDir, "S01-PLAN.md"),
+      `# Plan
+
+- [x] **T01: First** \`est:30m\`
+- [ ] **T02: Second** \`est:1h\`
+`
+    );
+
+    mockParseWorkflow.mockResolvedValue({
+      milestone: { id: "M001", title: "my feature" },
+      slice: { id: "S01", title: "Do things" },
+      task: { id: "T01", title: "First" },
+      phase: "build",
+      autoMode: null,
+    });
+
+    const result = await buildDashboardData(tmpDir);
+
+    const activeSlice = result!.slices.find(s => s.active);
+    expect(activeSlice).toBeDefined();
+    expect(activeSlice!.tasks).toHaveLength(2);
+    expect(activeSlice!.tasks[0]).toMatchObject({ id: "T01", done: true, estimate: "30m" });
+    expect(activeSlice!.tasks[1]).toMatchObject({ id: "T02", done: false, estimate: "1h" });
+    expect(activeSlice!.taskProgress).toEqual({ done: 1, total: 2 });
+  });
+
+  it("falls back to legacy milestones/ layout when phases/ absent", async () => {
+    const gsdDir = path.join(tmpDir, ".gsd");
+    const milestoneDir = path.join(gsdDir, "milestones", "M001");
+    fs.mkdirSync(milestoneDir, { recursive: true });
+    fs.writeFileSync(path.join(gsdDir, "STATE.md"), "");
+    fs.writeFileSync(
+      path.join(milestoneDir, "M001-ROADMAP.md"),
+      `- [ ] **S01: Legacy slice** \`risk:low\`\n`
+    );
+
+    mockParseWorkflow.mockResolvedValue({
+      milestone: { id: "M001", title: "Legacy" },
+      slice: { id: "S01", title: "Legacy slice" },
+      task: null,
+      phase: "build",
+      autoMode: null,
+    });
+
+    const result = await buildDashboardData(tmpDir);
+
+    expect(result!.slices).toHaveLength(1);
+    expect(result!.slices[0]).toMatchObject({ id: "S01", active: true });
+  });
+
   // ── gsd-pi 2.44 compatibility ──────────────────────────────────
 
   it("parses 2.44 milestone registry with all four glyphs", async () => {

--- a/src/extension/dashboard-parser.test.ts
+++ b/src/extension/dashboard-parser.test.ts
@@ -352,6 +352,69 @@ Execute T03 for S02
     expect(result!.slices[0]).toMatchObject({ id: "S01", active: true });
   });
 
+  it("prefers phases/ over milestones/ when both exist (mixed-layout)", async () => {
+    const gsdDir = path.join(tmpDir, ".gsd");
+    const phaseDir = path.join(gsdDir, "phases", "M001-new-feature");
+    const legacyDir = path.join(gsdDir, "milestones", "M001");
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(gsdDir, "STATE.md"), "");
+    // Both dirs have a roadmap but with different slice IDs so we can tell which was used
+    fs.writeFileSync(
+      path.join(phaseDir, "M001-ROADMAP.md"),
+      `- [ ] **S01: Flat-phase slice** \`risk:low\`\n`
+    );
+    fs.writeFileSync(
+      path.join(legacyDir, "M001-ROADMAP.md"),
+      `- [ ] **S01: Legacy slice** \`risk:low\`\n`
+    );
+
+    mockParseWorkflow.mockResolvedValue({
+      milestone: { id: "M001", title: "new feature" },
+      slice: { id: "S01", title: "Flat-phase slice" },
+      task: null,
+      phase: "build",
+      autoMode: null,
+    });
+
+    const result = await buildDashboardData(tmpDir);
+
+    expect(result!.slices).toHaveLength(1);
+    expect(result!.slices[0]).toMatchObject({ id: "S01", title: "Flat-phase slice" });
+  });
+
+  it("picks the alphabetically first match when multiple phase dirs share the same prefix", async () => {
+    const gsdDir = path.join(tmpDir, ".gsd");
+    // Simulate leftover migration dir alongside the real one
+    const phaseDir1 = path.join(gsdDir, "phases", "M001-alpha");
+    const phaseDir2 = path.join(gsdDir, "phases", "M001-zeta");
+    fs.mkdirSync(phaseDir1, { recursive: true });
+    fs.mkdirSync(phaseDir2, { recursive: true });
+    fs.writeFileSync(path.join(gsdDir, "STATE.md"), "");
+    fs.writeFileSync(
+      path.join(phaseDir1, "M001-ROADMAP.md"),
+      `- [ ] **S01: Alpha slice** \`risk:low\`\n`
+    );
+    fs.writeFileSync(
+      path.join(phaseDir2, "M001-ROADMAP.md"),
+      `- [ ] **S01: Zeta slice** \`risk:low\`\n`
+    );
+
+    mockParseWorkflow.mockResolvedValue({
+      milestone: { id: "M001", title: "alpha" },
+      slice: { id: "S01", title: "Alpha slice" },
+      task: null,
+      phase: "build",
+      autoMode: null,
+    });
+
+    const result = await buildDashboardData(tmpDir);
+
+    // Should deterministically pick M001-alpha (sorted first)
+    expect(result!.slices).toHaveLength(1);
+    expect(result!.slices[0]).toMatchObject({ id: "S01", title: "Alpha slice" });
+  });
+
   // ── gsd-pi 2.44 compatibility ──────────────────────────────────
 
   it("parses 2.44 milestone registry with all four glyphs", async () => {

--- a/src/extension/dashboard-parser.ts
+++ b/src/extension/dashboard-parser.ts
@@ -146,10 +146,11 @@ async function resolveMilestoneDir(gsdDir: string, mid: string): Promise<string>
   const phasesDir = path.join(gsdDir, "phases");
   try {
     const entries = await fs.promises.readdir(phasesDir);
-    const match = entries.find(e => e === mid || e.startsWith(mid + "-"));
-    if (match) {
-      return path.join(phasesDir, match);
-    }
+    // Exact match takes priority; among prefix matches sort for determinism
+    const exact = entries.find(e => e === mid);
+    if (exact) return path.join(phasesDir, exact);
+    const prefixed = entries.filter(e => e.startsWith(mid + "-")).sort();
+    if (prefixed.length > 0) return path.join(phasesDir, prefixed[0]);
   } catch {
     // phases/ doesn't exist — fall through to legacy layout
   }

--- a/src/extension/dashboard-parser.ts
+++ b/src/extension/dashboard-parser.ts
@@ -138,6 +138,41 @@ async function findFile(dir: string, suffix: string): Promise<string | null> {
 }
 
 /**
+ * Resolve the milestone directory, supporting both layouts:
+ *   flat-phase (v1.4.0+): .gsd/phases/{MID}-{slug}/
+ *   legacy (v1.3.x):      .gsd/milestones/{MID}/
+ */
+async function resolveMilestoneDir(gsdDir: string, mid: string): Promise<string> {
+  const phasesDir = path.join(gsdDir, "phases");
+  try {
+    const entries = await fs.promises.readdir(phasesDir);
+    const match = entries.find(e => e === mid || e.startsWith(mid + "-"));
+    if (match) {
+      return path.join(phasesDir, match);
+    }
+  } catch {
+    // phases/ doesn't exist — fall through to legacy layout
+  }
+  return path.join(gsdDir, "milestones", mid);
+}
+
+/**
+ * Resolve the slice directory, supporting both layouts:
+ *   flat-phase (v1.4.0+): slice plan lives directly in milestoneDir
+ *   legacy (v1.3.x):      milestoneDir/slices/{SID}/
+ */
+async function resolveSliceDir(milestoneDir: string, sliceId: string): Promise<string> {
+  // In flat-phase the PLAN.md lives directly in the milestone/phase dir
+  try {
+    await fs.promises.access(path.join(milestoneDir, `${sliceId}-PLAN.md`));
+    return milestoneDir;
+  } catch {
+    // Not found flat — use legacy nested layout
+    return path.join(milestoneDir, "slices", sliceId);
+  }
+}
+
+/**
  * Build the full dashboard data from .gsd/ project files.
  */
 export async function buildDashboardData(cwd: string): Promise<DashboardData | null> {
@@ -195,7 +230,7 @@ export async function buildDashboardData(cwd: string): Promise<DashboardData | n
   }
 
   const mid = wfState.milestone.id;
-  const milestoneDir = path.join(gsdDir, "milestones", mid);
+  const milestoneDir = await resolveMilestoneDir(gsdDir, mid);
 
   // Parse roadmap
   const roadmapFile = await findFile(milestoneDir, "-ROADMAP.md");
@@ -215,7 +250,7 @@ export async function buildDashboardData(cwd: string): Promise<DashboardData | n
 
       // If this is the active slice, parse its plan for tasks
       if (isActive) {
-        const sliceDir = path.join(milestoneDir, "slices", rs.id);
+        const sliceDir = await resolveSliceDir(milestoneDir, rs.id);
         const planFile = await findFile(sliceDir, "-PLAN.md");
         if (planFile) {
           const planContent = await fs.promises.readFile(planFile, "utf-8");


### PR DESCRIPTION
## Summary

- gsd-pi v1.4.0 auto-migrates `.gsd/milestones/{MID}/` to `.gsd/phases/{MID}-{slug}/` on startup
- The dashboard parser was hardcoded to the old nested path, causing slices and tasks to show as empty after upgrading
- Added layout-aware path resolution that checks `phases/` first, falls back to `milestones/` for v1.3.x projects

## What changed

Two new helpers in `dashboard-parser.ts`:
- `resolveMilestoneDir` - scans `.gsd/phases/` for a dir prefixed with the milestone ID, falls back to `.gsd/milestones/{MID}/`
- `resolveSliceDir` - checks flat-phase location (plan alongside roadmap in milestone dir), falls back to legacy `slices/{SID}/` subdir

## Backward compatibility

Projects on v1.3.x have no `phases/` directory and hit the legacy fallback immediately. Neither layout breaks the other.

## Test plan

- [x] 15 tests pass (10 existing + 5 new covering flat-phase, legacy fallback, and mixed layouts)
- [ ] Manual verification after upgrading gsd-pi to v1.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard content is now discovered correctly across both the newer flat-phase layout and the older milestone layout.
  * Roadmaps, slice plans, and task progress now surface more reliably when project files are organised differently.

* **Bug Fixes**
  * Fixed cases where active milestones, slices, or tasks were not being identified correctly in some workspace layouts.
  * Improved fallback behaviour so the dashboard still loads useful information when the newer structure is not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->