### PR TITLE
Fix live workflow card rendering above first reply of a turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Rokket GSD will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Live workflow card now sits at the launch point, not the top of the turn** — when the agent launched a workflow after several replies in the same turn, the live card was stranded above the turn's first reply. It now renders directly below the launching turn, where the work actually started, and stays there if the sidebar is rebuilt mid-run.
+
 ## [0.3.85] — 2026-06-21
 
 ### Fixed

--- a/src/webview/__tests__/workflow-live.test.ts
+++ b/src/webview/__tests__/workflow-live.test.ts
@@ -55,19 +55,19 @@ describe("workflow-live inline conversation card", () => {
     expect(el!.className).toContain("status-running");
   });
 
-  it("inserts the card above the launching turn, not after it", () => {
+  it("inserts the card below the launching turn, not above it", () => {
     // Two prior entries: the user's prompt and the assistant turn that launched
-    // the workflow. The card should land directly above the most recent entry.
+    // the workflow. The whole assistant turn is one entry and the Workflow call is
+    // the last thing in it, so the card should trail that entry, not head it.
     const container = document.getElementById("messagesContainer")!;
     container.innerHTML = `<div class="gsd-entry" data-entry-id="user"></div><div class="gsd-entry" data-entry-id="assistant"></div>`;
     update(snapshot());
     const kids = Array.from(container.children);
     const cardIdx = kids.indexOf(card()!);
     const assistantIdx = kids.indexOf(container.querySelector('[data-entry-id="assistant"]')!);
-    expect(cardIdx).toBe(assistantIdx - 1);
-    // And it sits after the earlier user entry — i.e. above only the last turn.
-    const userIdx = kids.indexOf(container.querySelector('[data-entry-id="user"]')!);
-    expect(cardIdx).toBeGreaterThan(userIdx);
+    // Directly after the launching turn — the last position in the container.
+    expect(cardIdx).toBe(assistantIdx + 1);
+    expect(cardIdx).toBe(kids.length - 1);
   });
 
   it("keeps one card per run id and updates it in place", () => {
@@ -154,12 +154,13 @@ describe("workflow-live inline conversation card", () => {
     // Card is still at position 0, before both entries — wrong.
     expect(container.children[0]).toBe(card());
 
-    // The heartbeat repositions it above the last entry.
+    // The heartbeat repositions it directly below the last entry.
     vi.advanceTimersByTime(1000);
     const kids = Array.from(container.children);
     const cardIdx = kids.indexOf(card()!);
     const assistantIdx = kids.indexOf(entry2);
-    expect(cardIdx).toBe(assistantIdx - 1);
+    expect(cardIdx).toBe(assistantIdx + 1);
+    expect(cardIdx).toBe(kids.length - 1);
   });
 
   it("does not run a heartbeat when the only run is already terminal", () => {

--- a/src/webview/workflow-live.ts
+++ b/src/webview/workflow-live.ts
@@ -52,18 +52,21 @@ function findCard(runId: string): HTMLElement | null {
 }
 
 /**
- * Place a card just *above* the most recent conversation entry — the assistant
- * turn that launched the workflow — so it reads as a header for that turn rather
- * than trailing underneath its text. No-ops if the card is already in the correct
- * position. Falls back to appending when no entry has rendered yet (the heartbeat
- * will reposition it once entries exist).
+ * Place a card just *below* the most recent conversation entry — the assistant
+ * turn that launched the workflow. The entire assistant turn (every streamed
+ * reply and tool call) is a single `.gsd-entry`, and the `Workflow` tool call is
+ * the last thing in it, so trailing the turn reads as "inline where the work was
+ * started". Inserting *above* the entry instead stranded the card over the turn's
+ * very first reply, far from the launch point, whenever the turn had many replies.
+ * No-ops if the card is already in the correct position. Falls back to appending
+ * when no entry has rendered yet (the heartbeat repositions it once entries exist).
  */
 function insertCardInto(container: HTMLElement, card: HTMLElement): void {
   const entries = container.querySelectorAll<HTMLElement>(".gsd-entry");
   const anchor = entries.length ? entries[entries.length - 1] : null;
   if (anchor) {
-    if (card.parentElement === container && card.nextSibling === anchor) return; // already correct
-    container.insertBefore(card, anchor);
+    if (card.parentElement === container && card.previousElementSibling === anchor) return; // already correct
+    anchor.after(card);
   } else {
     container.appendChild(card);
   }
@@ -132,8 +135,8 @@ function stopHeartbeat(): void {
  * ending. After a sidebar rebind the webview HTML is rebuilt before conversation
  * history re-renders, so a replayed card can land before any `.gsd-entry` exists
  * and end up stranded at the top of the container. The heartbeat corrects both
- * cases: missing cards are re-created; mispositioned cards (nextSibling is not
- * the last entry) are moved. Terminal cards are not tracked here.
+ * cases: missing cards are re-created; mispositioned cards (not sitting directly
+ * after the last entry) are moved. Terminal cards are not tracked here.
  */
 function heartbeatTick(): void {
   let anyLive = false;


### PR DESCRIPTION
## Problem

When the agent launches a Claude Code Workflow mid-turn, the live workflow card rendered **above the first LLM reply** of that turn instead of at the point where the workflow was actually invoked.

Root cause: an entire assistant turn (every streamed reply plus the `Workflow` tool call) is a single `.gsd-entry`. The card was inserted *above* that entry, stranding it over the turn's first reply, far from the launch point.

## Fix

`gsd-vscode/src/webview/workflow-live.ts`: insert the card directly *below* the last entry instead of above it.
- `insertCardInto` now calls `anchor.after(card)` (was `container.insertBefore(card, anchor)`); the already-correct guard checks `card.previousElementSibling === anchor`.
- Since the `Workflow` call is the last thing in the turn, trailing the entry reads as inline where the work started (bottom of the conversation).
- The heartbeat reposition logic follows the same rule, so a card that lands before entries render (sidebar rebind race) is moved back to trail the last entry.

## Tests

`src/webview/__tests__/workflow-live.test.ts` updated to assert the below-the-turn positions and the rebind-race reposition.

Verified 9/9 assertions against the real bundled source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the live workflow card so it now appears directly below the turn that starts the workflow.
  * Improved card placement during mid-run sidebar rebuilds, keeping it correctly aligned with the latest conversation entry.

* **Tests**
  * Updated automated checks to match the corrected card placement behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->