### PR TITLE
Fix release-bump commit author email

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Configure git
         run: |
           git config user.name "Kile Thomson"
-          git config user.email "260275437+Kile-Thomson@users.noreply.github.com"
+          git config user.email "kile.bantick@gmail.com"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The Release VSIX workflow committed its auto version-bump as `Kile Thomson <260275437+Kile-Thomson@users.noreply.github.com>`. This sets the git identity in the workflow's Configure git step to `kile.bantick@gmail.com` so future auto-bump commits carry the correct author email.

One-line change to `.github/workflows/release.yml`. No code, no history rewrite - only future bump commits are affected.