### PR TITLE
Stream tool calls inline instead of batching them at turn end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Rokket GSD will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Tool calls now stream inline as they run** — with the Claude Code backend, tool calls didn't appear in the transcript until the whole turn finished, then all landed at once. The backend's tool-start streaming event carries only a content index (no tool block), so the webview couldn't create the segment and silently skipped it; everything then rendered from the batched end-of-turn events. The webview now reads the tool block from the partial message attached to the event, and creates the segment on the tool-completion event as a further fallback, so each tool shows up with a live spinner the moment it starts. (#75)
+
 ## [0.3.97] — 2026-08-17
 
 ### Fixed

--- a/src/webview/__tests__/message-handler.test.ts
+++ b/src/webview/__tests__/message-handler.test.ts
@@ -680,6 +680,70 @@ describe("message-handler", () => {
       expect(tc.isRunning).toBe(false);
       expect(tc.endTime).toBeDefined();
     });
+
+    it("creates tool segment from bare toolcall_start via message content (claude-code shape)", () => {
+      sendMessage({ type: "agent_start" });
+
+      // claude-code provider: assistantMessageEvent has only contentIndex;
+      // the tool block lives in the partial message attached to the event.
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: { type: "toolcall_start", contentIndex: 1 },
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me check." },
+            { type: "toolCall", id: "cc1", name: "Bash", arguments: {} },
+          ],
+        },
+      });
+      const tc = state.currentTurn!.toolCalls.get("cc1")!;
+      expect(tc).toBeDefined();
+      expect(tc.isRunning).toBe(true);
+      expect(tc.name).toBe("Bash");
+      expect(renderer.appendToolSegmentElement).toHaveBeenCalled();
+    });
+
+    it("creates missing tool segment on toolcall_end so tools render inline, not batched at turn end", () => {
+      sendMessage({ type: "agent_start" });
+
+      // No toolcall_start was renderable — toolcall_end arrives with the full
+      // tool call (argument-completion event, no result yet).
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_end",
+          contentIndex: 0,
+          toolCall: { id: "cc2", name: "Read", arguments: { path: "a.ts" } },
+        },
+      });
+      const tc = state.currentTurn!.toolCalls.get("cc2")!;
+      expect(tc).toBeDefined();
+      expect(tc.isRunning).toBe(true);
+      expect(tc.args).toEqual({ path: "a.ts" });
+      expect(renderer.appendToolSegmentElement).toHaveBeenCalled();
+
+      // Second toolcall_end carries the external result — completes the segment.
+      sendMessage({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "toolcall_end",
+          contentIndex: 0,
+          toolCall: {
+            id: "cc2",
+            name: "Read",
+            arguments: { path: "a.ts" },
+            externalResult: { content: [{ text: "contents" }] },
+          },
+        },
+      });
+      expect(tc.isRunning).toBe(false);
+      expect(tc.resultText).toBe("contents");
+
+      // Late batched tool_execution_start must not resurrect the spinner.
+      sendMessage({ type: "tool_execution_start", toolCallId: "cc2", toolName: "Read", args: { path: "a.ts" } });
+      expect(tc.isRunning).toBe(false);
+    });
   });
 
   // ============================================================

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -614,6 +614,15 @@ function handleMessage(event: MessageEvent): void {
           if (!block && delta.toolCall) {
             block = delta.toolCall;
           }
+          if (!block) {
+            // claude-code provider: toolcall_start carries only contentIndex.
+            // The agent core attaches the partial message to the message_update
+            // event itself, so read the tool block from there.
+            const msgContent = data.message?.content;
+            if (Array.isArray(msgContent) && typeof idx === "number" && idx >= 0 && idx < msgContent.length) {
+              block = msgContent[idx];
+            }
+          }
           if (block) {
             const isToolBlock = block.type === "toolCall" || block.type === "tool_use" || block.type === "tool-use";
             if (isToolBlock && block.id && block.name) {
@@ -661,6 +670,40 @@ function handleMessage(event: MessageEvent): void {
           // Tool call complete — may carry externalResult with the tool's output.
           // Render the result immediately so users see it while the model continues.
           const tc2 = delta.toolCall;
+          // If streaming never created this segment (e.g. the toolcall_start
+          // event carried no tool block), create it now so the tool appears
+          // inline while it executes rather than batched at turn end.
+          if (tc2?.id && tc2.name && state.currentTurn && !state.currentTurn.toolCalls.has(tc2.id)) {
+            const turn = state.currentTurn;
+            const tc: ToolCallState = {
+              id: tc2.id,
+              name: tc2.name,
+              args: (tc2.arguments && typeof tc2.arguments === "object") ? tc2.arguments : {},
+              resultText: "",
+              isError: false,
+              isRunning: true,
+              startTime: Date.now(),
+              isParallel: false,
+            };
+            const runningOthers: ToolCallState[] = [];
+            for (const other of turn.toolCalls.values()) {
+              if (other.isRunning && other.id !== tc.id) runningOthers.push(other);
+            }
+            if (runningOthers.length > 0) {
+              tc.isParallel = true;
+              for (const rt of runningOthers) {
+                if (!rt.isParallel) {
+                  rt.isParallel = true;
+                  renderer.updateToolSegmentElement(rt.id);
+                }
+              }
+            }
+            turn.toolCalls.set(tc2.id, tc);
+            const segIdx = turn.segments.length;
+            turn.segments.push({ type: "tool", toolCallId: tc2.id });
+            renderer.appendToolSegmentElement(tc, segIdx);
+            scrollToBottom(messagesContainer);
+          }
           if (tc2?.id && tc2.externalResult && state.currentTurn) {
             const existing = state.currentTurn.toolCalls.get(tc2.id);
             if (existing) {


### PR DESCRIPTION
## Summary

Fixes #75. With the Claude Code backend, tool calls didn't appear in the transcript until the turn finished, then all rendered at once.

## Root cause

The claude-code provider's `toolcall_start` streaming event carries only a `contentIndex` - no partial content array and no `toolCall` block. The webview's streaming handler looked for the tool block in `delta.partial.content[idx]` or `delta.toolCall`, found neither, and silently skipped the event. Tool calls then only rendered when pi's synthetic `tool_execution_start`/`tool_execution_end` events flushed together after `message_end` (verified by timestamping the RPC stdout: three tools started at +9.5s, +12.5s, +15.2s, but all `tool_execution_*` events arrived at +18.6s).

## Fix

In the webview message handler:
- `toolcall_start`: fall back to reading the tool block from the partial message the agent core attaches to every `message_update` event (`msg.message.content[contentIndex]`).
- `toolcall_end`: create the segment if streaming never did, so the tool still renders inline with a spinner at argument-completion time and picks up its result from the follow-up event carrying `externalResult`.

## Testing

- Two new regression tests using the exact claude-code event shapes (bare `toolcall_start`, segment creation on `toolcall_end`, no spinner resurrection from late batched events).
- Full suite: 1400 tests pass, typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inline streaming for Claude Code tool calls, including cases where tool details arrive in partial messages.
  - Added fallback handling so completed tool calls are displayed correctly even when their initial streaming information is incomplete.
  - Prevented late execution updates from incorrectly reopening tools that have already finished.

- **Documentation**
  - Added an unreleased changelog entry describing the improved tool-call streaming behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->