### PR TITLE
Fix release notes fallback to range from last tag and filter housekeeping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,24 +112,35 @@ jobs:
           if not notes:
               # No CHANGELOG.md entry - generate from commits since the last tag
               try:
-                  last_tag = subprocess.run(
-                      ["git", "describe", "--tags", "--abbrev=0"],
-                      capture_output=True, text=True, timeout=10
+                  tag_list = subprocess.run(
+                      ["git", "tag", "--list"],
+                      capture_output=True, text=True, timeout=10, check=True
                   ).stdout.strip()
-                  rev_range = f"{last_tag}..HEAD" if last_tag else "HEAD"
+                  if tag_list:
+                      last_tag = subprocess.run(
+                          ["git", "describe", "--tags", "--abbrev=0"],
+                          capture_output=True, text=True, timeout=10, check=True
+                      ).stdout.strip()
+                      rev_range = f"{last_tag}..HEAD"
+                  else:
+                      # Repo genuinely has no tags yet - first release
+                      rev_range = "HEAD"
                   result = subprocess.run(
                       ["git", "log", "--no-merges", "--format=- %s", rev_range],
-                      capture_output=True, text=True, timeout=10
+                      capture_output=True, text=True, timeout=10, check=True
                   )
                   lines = result.stdout.strip().splitlines()
-              except Exception:
+              except Exception as exc:
+                  print(f"WARNING: git log fallback failed: {exc}", file=sys.stderr)
                   lines = []
 
               # Drop housekeeping commits that mean nothing to users
+              prefix = r"(?:\w+(\(.*\))?:\s*)?"
               skip = re.compile(
                   r"^- (chore(\(.*\))?:|ci(\(.*\))?:|docs(\(.*\))?:"
-                  r"|release \d|address coderabbit|use .* commit identity"
-                  r"|consolidate contributor identity|bump version)",
+                  rf"|{prefix}(release \d|address coderabbit"
+                  r"|use .* commit identity|consolidate contributor identity"
+                  r"|bump version))",
                   re.IGNORECASE,
               )
               commits = "\n".join(l for l in lines if l.strip() and not skip.match(l))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,17 +110,29 @@ jobs:
               notes = ""
 
           if not notes:
-              # No CHANGELOG.md entry — generate from git log since last tag
+              # No CHANGELOG.md entry - generate from commits since the last tag
               try:
+                  last_tag = subprocess.run(
+                      ["git", "describe", "--tags", "--abbrev=0"],
+                      capture_output=True, text=True, timeout=10
+                  ).stdout.strip()
+                  rev_range = f"{last_tag}..HEAD" if last_tag else "HEAD"
                   result = subprocess.run(
-                      ["git", "log", "--oneline", "--no-merges",
-                       "--format=- %s", "HEAD~10..HEAD",
-                       "--invert-grep", "--grep=chore: bump version"],
+                      ["git", "log", "--no-merges", "--format=- %s", rev_range],
                       capture_output=True, text=True, timeout=10
                   )
-                  commits = result.stdout.strip()
+                  lines = result.stdout.strip().splitlines()
               except Exception:
-                  commits = ""
+                  lines = []
+
+              # Drop housekeeping commits that mean nothing to users
+              skip = re.compile(
+                  r"^- (chore(\(.*\))?:|ci(\(.*\))?:|docs(\(.*\))?:"
+                  r"|release \d|address coderabbit|use .* commit identity"
+                  r"|consolidate contributor identity|bump version)",
+                  re.IGNORECASE,
+              )
+              commits = "\n".join(l for l in lines if l.strip() and not skip.match(l))
 
               if commits:
                   notes = "### Changes\n\n" + commits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,8 @@ jobs:
                   )
                   lines = result.stdout.strip().splitlines()
               except Exception as exc:
-                  print(f"WARNING: git log fallback failed: {exc}", file=sys.stderr)
-                  lines = []
+                  print(f"ERROR: git history fallback failed: {exc}", file=sys.stderr)
+                  raise
 
               # Drop housekeeping commits that mean nothing to users
               prefix = r"(?:\w+(\(.*\))?:\s*)?"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
               # No CHANGELOG.md entry - generate from commits since the last tag
               try:
                   tag_list = subprocess.run(
-                      ["git", "tag", "--list"],
+                      ["git", "tag", "--list", "--merged", "HEAD"],
                       capture_output=True, text=True, timeout=10, check=True
                   ).stdout.strip()
                   if tag_list:


### PR DESCRIPTION
When a version has no CHANGELOG.md entry, the release workflow generated notes from a fixed HEAD~10..HEAD window. That dumped every recent commit subject into the published release notes, including identity fixups and commits already shipped in earlier releases (v0.3.98-v0.3.101 all had this noise; their notes have been cleaned by hand).

This changes the fallback to:
- Range from the last tag (git describe --tags --abbrev=0) instead of a fixed 10-commit window, so only commits actually in the release appear.
- Filter housekeeping subjects (chore:/ci:/docs: prefixes, version bumps, CodeRabbit fixups, identity commits).
- Fall back to "Patch release." when nothing user-facing remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Release notes are automatically generated from relevant commits when no changelog entry is available.
  - Releases without a previous tag can generate notes from the available commit history.
  - Housekeeping changes, including documentation, CI, release and version updates, are excluded from generated notes.
  - Housekeeping filtering recognises optional prefixes and is case-insensitive.
  - Changelog generation now reports an error when commit history cannot be retrieved, rather than producing empty notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->