### PR TITLE
Remove extension-host blocking calls and reduce streaming render cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+- **Update checks no longer briefly freeze the editor** — resolving a GitHub token via `gh auth token` or `git credential-manager` ran synchronously on the extension host thread, so every extension in the window could stall for the duration of the subprocess (noticeably longer on Windows). Both lookups now run asynchronously.
+- **Faster `/ollama` status** — the version, loaded-models, and installed-models endpoints are fetched concurrently instead of one after another.
+- **Long streaming replies stay smooth** — accumulated reply text is now compacted as it streams, so each render frame pays for the new text only instead of re-joining the whole reply. Also fixes the Telegram project search reading directories synchronously on the extension host thread.
+
 ### Fixed
 - **Messages typed during auto-mode now queue instead of hijacking the run** — auto-mode executes as a series of discrete agent turns, and the input box only queued messages while a turn was actively streaming. A message sent in the gap between iterations went out as a fresh prompt, which interrupted the auto engine, forced an immediate reply, dropped the session out of auto-mode, and could corrupt the workflow state database. The webview now queues any non-slash message while auto-mode is running (streaming or not), and the extension host applies the same guard as a backstop so other entry points (e.g. Telegram) can't interrupt a run either. Queued messages are delivered to the agent between iterations. Slash commands still send immediately, and messages during a discussion pause still reach the agent directly.
 - **Tool calls now stream inline as they run** — with the Claude Code backend, tool calls didn't appear in the transcript until the whole turn finished, then all landed at once. The backend's tool-start streaming event carries only a content index (no tool block), so the webview couldn't create the segment and silently skipped it; everything then rendered from the batched end-of-turn events. The webview now reads the tool block from the partial message attached to the event, and creates the segment on the tool-completion event as a further fallback, so each tool shows up with a live spinner the moment it starts. (#75)

--- a/src/extension/command-fallback.ts
+++ b/src/extension/command-fallback.ts
@@ -534,17 +534,25 @@ async function handleOllamaStatus(): Promise<string> {
 
   const lines: string[] = ["## \u{1F7E2} Ollama Running\n"];
 
+  // The three endpoints are independent — fetch them concurrently
+  const [versionResult, psResult, tagsResult] = await Promise.allSettled([
+    ollamaGet("/api/version"),
+    ollamaGet("/api/ps"),
+    ollamaGet("/api/tags"),
+  ]);
+
   try {
-    const versionRaw = await ollamaGet("/api/version");
-    const version = JSON.parse(versionRaw) as { version?: string };
-    if (version.version) lines.push(`**Version:** \`${version.version}\`\n`);
+    if (versionResult.status === "fulfilled") {
+      const version = JSON.parse(versionResult.value) as { version?: string };
+      if (version.version) lines.push(`**Version:** \`${version.version}\`\n`);
+    }
   } catch { /* version endpoint optional */ }
 
   // Loaded models (in VRAM)
   let loadedNames: Set<string> | undefined;
   try {
-    const psRaw = await ollamaGet("/api/ps");
-    const ps = JSON.parse(psRaw) as { models?: OllamaModelInfo[] };
+    if (psResult.status !== "fulfilled") throw new Error("ps unavailable");
+    const ps = JSON.parse(psResult.value) as { models?: OllamaModelInfo[] };
     if (ps.models?.length) {
       loadedNames = new Set(ps.models.map(m => m.name));
       lines.push("### Loaded in Memory\n");
@@ -563,8 +571,8 @@ async function handleOllamaStatus(): Promise<string> {
 
   // Available models (installed on disk)
   try {
-    const tagsRaw = await ollamaGet("/api/tags");
-    const tags = JSON.parse(tagsRaw) as { models?: OllamaModelInfo[] };
+    if (tagsResult.status !== "fulfilled") throw new Error("tags unavailable");
+    const tags = JSON.parse(tagsResult.value) as { models?: OllamaModelInfo[] };
     if (tags.models?.length) {
       const unloaded = loadedNames ? tags.models.filter(m => !loadedNames!.has(m.name)) : tags.models;
       if (unloaded.length) {

--- a/src/extension/telegram/bridge.test.ts
+++ b/src/extension/telegram/bridge.test.ts
@@ -5,14 +5,19 @@ import type { TopicManager, TopicManagerLogger } from "./topicManager";
 import type { BridgeClient, BridgeSessionState } from "./bridge";
 import * as fs from "fs";
 
-vi.mock("fs", () => ({
-  existsSync: vi.fn().mockReturnValue(false),
-  readdirSync: vi.fn().mockReturnValue([]),
-  default: {
+vi.mock("fs", () => {
+  const promises = { readdir: vi.fn().mockRejectedValue(new Error("ENOENT")) };
+  return {
     existsSync: vi.fn().mockReturnValue(false),
     readdirSync: vi.fn().mockReturnValue([]),
-  },
-}));
+    promises,
+    default: {
+      existsSync: vi.fn().mockReturnValue(false),
+      readdirSync: vi.fn().mockReturnValue([]),
+      promises,
+    },
+  };
+});
 
 function createMockApi(updates: TelegramUpdate[] = []): TelegramApi {
   let callCount = 0;
@@ -1090,13 +1095,11 @@ describe("TelegramBridge", () => {
   describe("project finder", () => {
     beforeEach(() => {
       setup();
-      vi.mocked(fs.existsSync).mockReturnValue(false);
-      vi.mocked(fs.readdirSync).mockReturnValue([]);
+      vi.mocked(fs.promises.readdir).mockRejectedValue(new Error("ENOENT"));
     });
 
     function mockDirs(baseDir: string, subdirs: string[]) {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readdirSync).mockReturnValue(
+      vi.mocked(fs.promises.readdir).mockResolvedValue(
         subdirs.map((name) => ({
           name,
           isDirectory: () => true,
@@ -1112,72 +1115,70 @@ describe("TelegramBridge", () => {
       );
     }
 
-    it("returns empty when no search dirs configured", () => {
-      expect(bridge.findProjects("rokketdocs")).toEqual([]);
+    it("returns empty when no search dirs configured", async () => {
+      await expect(bridge.findProjects("rokketdocs")).resolves.toEqual([]);
     });
 
-    it("finds exact folder name match", () => {
+    it("finds exact folder name match", async () => {
       bridge.setProjectSearchDirs(["/projects"]);
       mockDirs("/projects", ["RokketDocs", "OtherProject"]);
-      const results = bridge.findProjects("rokketdocs");
+      const results = await bridge.findProjects("rokketdocs");
       expect(results).toHaveLength(1);
       expect(results[0]).toContain("RokketDocs");
     });
 
-    it("finds partial match", () => {
+    it("finds partial match", async () => {
       bridge.setProjectSearchDirs(["/projects"]);
       mockDirs("/projects", ["RokketDocs-Frontend", "Backend"]);
-      const results = bridge.findProjects("rokketdocs");
+      const results = await bridge.findProjects("rokketdocs");
       expect(results).toHaveLength(1);
       expect(results[0]).toContain("RokketDocs-Frontend");
     });
 
-    it("strips stop words from query", () => {
+    it("strips stop words from query", async () => {
       bridge.setProjectSearchDirs(["/projects"]);
       mockDirs("/projects", ["RokketDocs", "MyApp"]);
-      const results = bridge.findProjects("hey launch my rokketdocs folder please");
+      const results = await bridge.findProjects("hey launch my rokketdocs folder please");
       expect(results).toHaveLength(1);
       expect(results[0]).toContain("RokketDocs");
     });
 
-    it("ranks exact match higher than partial", () => {
+    it("ranks exact match higher than partial", async () => {
       bridge.setProjectSearchDirs(["/projects"]);
       mockDirs("/projects", ["RokketDocs-Old", "RokketDocs"]);
-      const results = bridge.findProjects("rokketdocs");
+      const results = await bridge.findProjects("rokketdocs");
       expect(results[0]).toContain("RokketDocs");
     });
 
-    it("returns multiple matches sorted by score", () => {
+    it("returns multiple matches sorted by score", async () => {
       bridge.setProjectSearchDirs(["/projects"]);
       mockDirs("/projects", ["Alpha", "Beta", "AlphaBeta"]);
-      const results = bridge.findProjects("alpha");
+      const results = await bridge.findProjects("alpha");
       expect(results.length).toBeGreaterThanOrEqual(2);
     });
 
-    it("skips hidden directories", () => {
+    it("skips hidden directories", async () => {
       bridge.setProjectSearchDirs(["/projects"]);
       mockDirs("/projects", [".hidden", "Visible"]);
-      const results = bridge.findProjects("hidden");
+      const results = await bridge.findProjects("hidden");
       expect(results).toEqual([]);
     });
 
-    it("returns empty when all words are stop words", () => {
+    it("returns empty when all words are stop words", async () => {
       bridge.setProjectSearchDirs(["/projects"]);
       mockDirs("/projects", ["SomeProject"]);
-      const results = bridge.findProjects("hey launch my project");
+      const results = await bridge.findProjects("hey launch my project");
       expect(results).toEqual([]);
     });
   });
 
   describe("general chat project search", () => {
     beforeEach(() => {
-      vi.mocked(fs.existsSync).mockReturnValue(false);
-      vi.mocked(fs.readdirSync).mockReturnValue([]);
+      vi.mocked(fs.promises.readdir).mockRejectedValue(new Error("ENOENT"));
     });
 
     function mockProjectDirs(subdirs: string[]) {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readdirSync).mockReturnValue(
+      vi.mocked(fs.promises.readdir).mockResolvedValue(
         subdirs.map((name) => ({
           name,
           isDirectory: () => true,
@@ -1239,7 +1240,6 @@ describe("TelegramBridge", () => {
     it("shows hint when no session and search dirs configured but no match", async () => {
       setup();
       bridge.setProjectSearchDirs(["/projects"]);
-      vi.mocked(fs.existsSync).mockReturnValue(true);
 
       await bridge._testInjectUpdates([{
         update_id: 1,
@@ -1282,7 +1282,6 @@ describe("TelegramBridge", () => {
       setup([], new Map(), new Map(), new Map([["s1", { client, isStreaming: false, autoModeState: null }]]));
       bridge.setGeneralSession("s1");
       bridge.setProjectSearchDirs(["/projects"]);
-      vi.mocked(fs.existsSync).mockReturnValue(true);
 
       await bridge._testInjectUpdates([{
         update_id: 1,

--- a/src/extension/telegram/bridge.ts
+++ b/src/extension/telegram/bridge.ts
@@ -158,7 +158,7 @@ export class TelegramBridge {
     this.projectSearchDirs = dirs;
   }
 
-  findProjects(query: string): string[] {
+  async findProjects(query: string): Promise<string[]> {
     const stopWords = new Set([
       "hey", "hi", "hello", "please", "can", "you", "the", "a", "an",
       "my", "in", "it", "its", "is", "at", "to", "for", "of", "on",
@@ -178,10 +178,11 @@ export class TelegramBridge {
     const matches: { dir: string; score: number }[] = [];
 
     for (const baseDir of this.projectSearchDirs) {
-      if (!fs.existsSync(baseDir)) continue;
       let entries: fs.Dirent[];
       try {
-        entries = fs.readdirSync(baseDir, { withFileTypes: true });
+        // Async so a slow (e.g. Dropbox-synced) directory never blocks the
+        // extension host; a missing dir rejects and is skipped like before.
+        entries = await fs.promises.readdir(baseDir, { withFileTypes: true });
       } catch {
         continue;
       }
@@ -441,7 +442,7 @@ export class TelegramBridge {
 
   private async tryProjectSearch(text: string): Promise<boolean> {
     if (this.projectSearchDirs.length === 0) return false;
-    const matches = this.findProjects(text);
+    const matches = await this.findProjects(text);
     if (matches.length === 0) return false;
     if (matches.length === 1) {
       await this.handleLaunchCommand(matches[0]);

--- a/src/extension/update-checker.test.ts
+++ b/src/extension/update-checker.test.ts
@@ -47,9 +47,9 @@ vi.mock("https", () => ({
 }));
 
 // ── Mock child_process ──
-const mockExecSync = vi.fn();
+const mockExecFile = vi.fn();
 vi.mock("child_process", () => ({
-  execSync: (...args: unknown[]) => mockExecSync(...args),
+  execFile: (...args: unknown[]) => mockExecFile(...args),
 }));
 
 // ── Mock fs ──
@@ -113,8 +113,12 @@ describe("update-checker", () => {
     mockGetExtension.mockReturnValue({
       packageJSON: { version: "1.0.0" },
     });
-    mockExecSync.mockImplementation(() => {
-      throw new Error("not found");
+    // execFile(cmd, args, opts, cb) — report "not found" via the callback and
+    // return a child whose stdin absorbs writes without throwing
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (err: Error | null, stdout: string) => void;
+      process.nextTick(() => cb(new Error("not found"), ""));
+      return { stdin: { on: vi.fn(), write: vi.fn(), end: vi.fn() } };
     });
   });
 

--- a/src/extension/update-checker.ts
+++ b/src/extension/update-checker.ts
@@ -3,7 +3,7 @@ import * as https from "https";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { execSync } from "child_process";
+import { execFile } from "child_process";
 import { toErrorMessage } from "../shared/errors";
 import type { GsdWebviewProvider } from "./webview-provider";
 import { UPDATE_CHECK_INTERVAL_MS } from "../shared/constants";
@@ -34,11 +34,35 @@ let cachedProvider: GsdWebviewProvider | null = null;
 // ─── Token resolution ─────────────────────────────────────────────────────────
 
 /**
+ * Run a command asynchronously, optionally feeding stdin, and return trimmed
+ * stdout. Rejects on spawn failure, non-zero exit, or timeout.
+ */
+function runCommand(cmd: string, args: string[], input?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      cmd,
+      args,
+      { encoding: "utf8", timeout: 5000, windowsHide: true },
+      (err, stdout) => {
+        if (err) reject(err);
+        else resolve(stdout.trim());
+      }
+    );
+    if (input !== undefined && child.stdin) {
+      child.stdin.on("error", () => { /* child exited early — exec callback reports it */ });
+      child.stdin.write(input);
+      child.stdin.end();
+    }
+  });
+}
+
+/**
  * Resolve a GitHub token for private repo API access.
  * Tries multiple sources so the user doesn't need to configure anything
  * if they already have gh or git set up.
+ * Async so the gh/git subprocess spawns never block the extension host.
  */
-function getGitHubToken(): string | undefined {
+async function getGitHubToken(): Promise<string | undefined> {
   // Return cached result (even if null = "no token found")
   if (cachedToken !== undefined) return cachedToken || undefined;
 
@@ -66,12 +90,7 @@ function getGitHubToken(): string | undefined {
 
   // 3. GitHub CLI (gh auth token)
   try {
-    const ghToken = execSync("gh auth token", {
-      encoding: "utf8",
-      timeout: 5000,
-      stdio: ["pipe", "pipe", "pipe"],
-      windowsHide: true,
-    }).trim();
+    const ghToken = await runCommand("gh", ["auth", "token"]);
     if (ghToken) {
       cachedToken = ghToken;
       return ghToken;
@@ -82,16 +101,11 @@ function getGitHubToken(): string | undefined {
 
   // 4. Git credential manager
   try {
-    const credOutput = execSync(
-      "git credential-manager get",
-      {
-        encoding: "utf8",
-        timeout: 5000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-        input: "protocol=https\nhost=github.com\n\n",
-      }
-    ).trim();
+    const credOutput = await runCommand(
+      "git",
+      ["credential-manager", "get"],
+      "protocol=https\nhost=github.com\n\n"
+    );
     const passwordMatch = credOutput.match(/^password=(.+)$/m);
     if (passwordMatch?.[1]?.trim()) {
       cachedToken = passwordMatch[1].trim();
@@ -108,12 +122,12 @@ function getGitHubToken(): string | undefined {
 /**
  * Build HTTP request headers, adding auth if a token is available.
  */
-function githubHeaders(): Record<string, string> {
+async function githubHeaders(): Promise<Record<string, string>> {
   const headers: Record<string, string> = {
     "User-Agent": "Rokket-GSD-VSCode",
     Accept: "application/vnd.github.v3+json",
   };
-  const token = getGitHubToken();
+  const token = await getGitHubToken();
   if (token) {
     headers["Authorization"] = `token ${token}`;
   }
@@ -214,8 +228,8 @@ export async function fetchReleaseNotes(version: string): Promise<string | null>
   const tag = version.startsWith("v") ? version : `v${version}`;
   const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/tags/${tag}`;
 
+  const headers = await githubHeaders();
   return new Promise((resolve) => {
-    const headers = githubHeaders();
     const req = https.get(url, { headers, timeout: API_TIMEOUT_MS }, (res) => {
       if (res.statusCode !== 200) {
         res.resume();
@@ -245,8 +259,8 @@ export async function fetchReleaseNotes(version: string): Promise<string | null>
 export async function fetchRecentReleases(count = 10): Promise<Array<{ version: string; notes: string; date: string }>> {
   const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases?per_page=${count}`;
 
+  const headers = await githubHeaders();
   return new Promise((resolve) => {
-    const headers = githubHeaders();
     const req = https.get(url, { headers, timeout: API_TIMEOUT_MS }, (res) => {
       if (res.statusCode !== 200) {
         res.resume();
@@ -409,10 +423,9 @@ function isGitHubHost(url: string): boolean {
 /** Timeout for API calls: 30 seconds */
 const API_TIMEOUT_MS = 30_000;
 
-function fetchLatestRelease(): Promise<ReleaseInfo | null> {
+async function fetchLatestRelease(): Promise<ReleaseInfo | null> {
+  const headers = await githubHeaders();
   return new Promise((resolve) => {
-    const headers = githubHeaders();
-
     const req = https
       .get(RELEASES_API, { headers, timeout: API_TIMEOUT_MS }, (res) => {
         if (res.statusCode === 404 || res.statusCode === 403) {
@@ -496,7 +509,9 @@ const DOWNLOAD_TIMEOUT_MS = 120_000;
  * Download a file, following redirects.
  * Adds GitHub auth for github.com URLs, strips it for CDN redirects.
  */
-function downloadFile(url: string, dest: string): Promise<void> {
+async function downloadFile(url: string, dest: string): Promise<void> {
+  // Resolve auth once up front — request() below runs in callback context
+  const token = await getGitHubToken();
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
     let settled = false;
@@ -543,7 +558,6 @@ function downloadFile(url: string, dest: string): Promise<void> {
 
       // Auth for GitHub-hosted URLs only — CDN redirects don't need it
       if (isGitHubHost(downloadUrl)) {
-        const token = getGitHubToken();
         if (token) headers["Authorization"] = `token ${token}`;
         headers["Accept"] = "application/octet-stream";
       }

--- a/src/webview/dispose.ts
+++ b/src/webview/dispose.ts
@@ -14,6 +14,11 @@ export function registerTimeout(id: string, handle: ReturnType<typeof setTimeout
   timeouts.set(id, handle);
 }
 
+/** Drop a timeout's registry entry once it has fired, so unique ids don't accumulate. */
+export function unregisterTimeout(id: string): void {
+  timeouts.delete(id);
+}
+
 export function registerCleanup(id: string, fn: () => void): void {
   cleanups.set(id, fn);
 }

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -1431,7 +1431,7 @@ function handleMessage(event: MessageEvent): void {
         toast.className = "gsd-toast gsd-toast-error";
         toast.textContent = ve.message || "Voice transcription failed";
         toastContainer.appendChild(toast);
-        setTimeout(() => toast.remove(), 5000);
+        registerTimeout("voice-error-toast", setTimeout(() => toast.remove(), 5000));
       }
       break;
     }

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -36,7 +36,10 @@ import * as workflowLive from "./workflow-live";
 import * as visualizer from "./visualizer";
 import * as fileHandling from "./file-handling";
 import { announceToScreenReader, createFocusTrap, restoreFocus } from "./a11y";
-import { registerTimeout } from "./dispose";
+import { registerTimeout, unregisterTimeout } from "./dispose";
+
+// Unique id per voice-error toast so overlapping toasts keep independent removal timers.
+let voiceErrorToastSeq = 0;
 import { setChangelogHandlers, getChangelogTriggerEl, dismissChangelog } from "./keyboard";
 
 // ============================================================
@@ -1431,7 +1434,11 @@ function handleMessage(event: MessageEvent): void {
         toast.className = "gsd-toast gsd-toast-error";
         toast.textContent = ve.message || "Voice transcription failed";
         toastContainer.appendChild(toast);
-        registerTimeout("voice-error-toast", setTimeout(() => toast.remove(), 5000));
+        const toastId = `voice-error-toast-${voiceErrorToastSeq++}`;
+        registerTimeout(toastId, setTimeout(() => {
+          unregisterTimeout(toastId);
+          toast.remove();
+        }, 5000));
       }
       break;
     }

--- a/src/webview/render/streaming.ts
+++ b/src/webview/render/streaming.ts
@@ -51,6 +51,18 @@ export function resetStreamingInternals(): void {
   _activeSegmentIndex = -1;
 }
 
+/**
+ * Join a segment's chunks and compact them into a single chunk, so the next
+ * join only pays for deltas that arrived since — keeps per-frame cost O(new
+ * text) instead of O(total text) on long streaming turns.
+ */
+function segmentText(seg: { chunks: string[] }): string {
+  if (seg.chunks.length === 1) return seg.chunks[0];
+  const full = seg.chunks.join("");
+  seg.chunks = [full];
+  return full;
+}
+
 function startElapsedTimer(): void {
   if (elapsedTimerHandle) return;
   elapsedTimerHandle = setInterval(() => {
@@ -151,7 +163,7 @@ export function appendToTextSegment(segType: "text" | "thinking", delta: string)
       if (seg.type === "text") {
         const incState = incrementalState.get(segIdx);
         const base = incState?.textLengthAtLastRaf ?? 0;
-        const fullText = seg.chunks.join("");
+        const fullText = segmentText(seg);
         liveNode.data = fullText.slice(base);
       }
     } else if (!segmentElements.has(segIdx)) {
@@ -174,7 +186,7 @@ export function appendToTextSegment(segType: "text" | "thinking", delta: string)
       const content = el.querySelector(".gsd-thinking-content");
       if (content) {
         const seg = turn.segments[segIdx];
-        if (seg.type === "thinking") content.textContent = seg.chunks.join("");
+        if (seg.type === "thinking") content.textContent = segmentText(seg);
       }
     } else if (!segmentElements.has(segIdx)) {
       const container = ensureCurrentTurnElement();
@@ -388,7 +400,7 @@ function renderTextSegment(segIdx: number): void {
   const container = ensureCurrentTurnElement();
   removePendingDotsFromContainer(container);
   let el = segmentElements.get(segIdx);
-  const fullText = seg.chunks.join("");
+  const fullText = segmentText(seg);
 
   if (seg.type === "thinking") {
     if (!el) {

--- a/src/webview/render/streaming.ts
+++ b/src/webview/render/streaming.ts
@@ -26,7 +26,6 @@ const incrementalState = new Map<number, {
   frozenBlockCount: number;
   lastLexedText: string;
   lastTokens: TokensList;
-  textLengthAtLastRaf: number;
 }>();
 const liveTextNodes = new Map<number, Text>();
 let elapsedTimerHandle: ReturnType<typeof setInterval> | null = null;
@@ -58,7 +57,10 @@ export function resetStreamingInternals(): void {
  */
 function segmentText(seg: { chunks: string[] }): string {
   if (seg.chunks.length === 1) return seg.chunks[0];
-  const full = seg.chunks.join("");
+  // Append onto the compacted prefix instead of join() — engines back string
+  // concatenation with ropes, so each += costs O(delta), not O(total).
+  let full = seg.chunks[0] ?? "";
+  for (let i = 1; i < seg.chunks.length; i++) full += seg.chunks[i];
   seg.chunks = [full];
   return full;
 }
@@ -159,13 +161,10 @@ export function appendToTextSegment(segType: "text" | "thinking", delta: string)
   if (segType === "text") {
     const liveNode = liveTextNodes.get(segIdx);
     if (liveNode) {
-      const seg = turn.segments[segIdx];
-      if (seg.type === "text") {
-        const incState = incrementalState.get(segIdx);
-        const base = incState?.textLengthAtLastRaf ?? 0;
-        const fullText = segmentText(seg);
-        liveNode.data = fullText.slice(base);
-      }
+      // The RAF render resets the live node to "" and re-anchors it after the
+      // trailing block, so appending just the delta keeps the node equal to
+      // "text since last frame" without ever touching the full prefix.
+      liveNode.data += delta;
     } else if (!segmentElements.has(segIdx)) {
       const container = ensureCurrentTurnElement();
       removePendingDotsFromContainer(container);
@@ -436,7 +435,7 @@ function renderTextSegment(segIdx: number): void {
     }
     let incState = incrementalState.get(segIdx);
     if (!incState) {
-      incState = { frozenBlockCount: 0, lastLexedText: "", lastTokens: Object.assign([] as Token[], { links: {} }) as TokensList, textLengthAtLastRaf: 0 };
+      incState = { frozenBlockCount: 0, lastLexedText: "", lastTokens: Object.assign([] as Token[], { links: {} }) as TokensList };
       incrementalState.set(segIdx, incState);
     }
     let tokens: TokensList;
@@ -473,7 +472,6 @@ function renderTextSegment(segIdx: number): void {
     const links = tokens.links || {};
     const trailingArr = Object.assign([trailingToken], { links });
     trailingEl.innerHTML = sanitizeAndPostProcess(parseTokens(trailingArr));
-    incState.textLengthAtLastRaf = fullText.length;
     const liveSpan = document.createElement("span");
     liveSpan.dataset.liveText = "";
     const liveNode = document.createTextNode("");

--- a/src/webview/toasts.ts
+++ b/src/webview/toasts.ts
@@ -3,8 +3,10 @@
 // ============================================================
 
 import { TOAST_DEFAULT_DURATION_MS, CSS_ANIMATION_SETTLE_MS } from "../shared/constants";
+import { registerTimeout } from "./dispose";
 
 let container: HTMLElement;
+let toastSeq = 0;
 
 export function init(el: HTMLElement): void {
   container = el;
@@ -23,10 +25,14 @@ export function show(message: string, duration = TOAST_DEFAULT_DURATION_MS): voi
     toast.classList.add("visible");
   });
 
-  setTimeout(() => {
+  // Rotate over a small id pool so the dispose registry doesn't grow unboundedly;
+  // 8 slots comfortably exceeds the number of simultaneously visible toasts.
+  const id = `toast-${toastSeq}`;
+  toastSeq = (toastSeq + 1) % 8;
+  registerTimeout(`${id}-dismiss`, setTimeout(() => {
     toast.classList.remove("visible");
     toast.addEventListener("transitionend", () => toast.remove(), { once: true });
     // Fallback removal if transitionend doesn't fire
-    setTimeout(() => toast.remove(), CSS_ANIMATION_SETTLE_MS);
-  }, duration);
+    registerTimeout(`${id}-remove`, setTimeout(() => toast.remove(), CSS_ANIMATION_SETTLE_MS));
+  }, duration));
 }

--- a/src/webview/toasts.ts
+++ b/src/webview/toasts.ts
@@ -3,7 +3,7 @@
 // ============================================================
 
 import { TOAST_DEFAULT_DURATION_MS, CSS_ANIMATION_SETTLE_MS } from "../shared/constants";
-import { registerTimeout } from "./dispose";
+import { registerTimeout, unregisterTimeout } from "./dispose";
 
 let container: HTMLElement;
 let toastSeq = 0;
@@ -25,14 +25,17 @@ export function show(message: string, duration = TOAST_DEFAULT_DURATION_MS): voi
     toast.classList.add("visible");
   });
 
-  // Rotate over a small id pool so the dispose registry doesn't grow unboundedly;
-  // 8 slots comfortably exceeds the number of simultaneously visible toasts.
-  const id = `toast-${toastSeq}`;
-  toastSeq = (toastSeq + 1) % 8;
+  // Unique id per toast so one toast's timers can never cancel another's; each
+  // entry unregisters itself on fire so the registry doesn't grow unboundedly.
+  const id = `toast-${toastSeq++}`;
   registerTimeout(`${id}-dismiss`, setTimeout(() => {
+    unregisterTimeout(`${id}-dismiss`);
     toast.classList.remove("visible");
     toast.addEventListener("transitionend", () => toast.remove(), { once: true });
     // Fallback removal if transitionend doesn't fire
-    registerTimeout(`${id}-remove`, setTimeout(() => toast.remove(), CSS_ANIMATION_SETTLE_MS));
+    registerTimeout(`${id}-remove`, setTimeout(() => {
+      unregisterTimeout(`${id}-remove`);
+      toast.remove();
+    }, CSS_ANIMATION_SETTLE_MS));
   }, duration));
 }


### PR DESCRIPTION
## Summary

Fixes from a performance audit of the extension:

- **update-checker**: GitHub token resolution via `gh auth token` / `git credential-manager` used `execSync`, freezing the extension host (and every extension in the window) for the duration of the subprocess spawn. Now uses async `execFile`; the download path resolves the token once up front.
- **telegram bridge**: project search read directories with `existsSync` + `readdirSync` on the event loop. Now uses `fs.promises.readdir` (a missing dir rejects and is skipped, so `existsSync` is gone entirely).
- **/ollama status**: the version, loaded-models, and installed-models endpoints are independent and are now fetched concurrently with `Promise.allSettled`.
- **streaming renderer**: each frame joined the segment's full chunk array (O(total text) per frame). Chunks are now compacted into a single string after each join, so a frame only pays for text that arrived since the last one.
- **webview cleanup**: two stray toast `setTimeout`s now go through the `dispose.ts` registry like the rest of the codebase.

## Testing

- `tsc --noEmit` clean, eslint clean
- Full vitest suite: 1410 tests, 72 files, all passing (bridge and update-checker tests updated for the async APIs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness by running status checks and authentication lookups asynchronously.
  * Reduced processing overhead while displaying streaming replies.
  * Project searches no longer block while reading directories.

* **Bug Fixes**
  * Ollama status results remain available when one endpoint is unavailable.
  * Improved cleanup of toast notifications and voice-error messages.
  * Prevented notification timers from interfering with one another.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->