### PR TITLE
Rich workflow-state hover popover and Codex reply formatting fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+- **Rich workflow-state popover** — hovering (or keyboard-focusing) the GSD workflow badge in the header now opens a detail panel instead of a bare tooltip: milestone, slice, and task titles with the milestone's position in the registry, slice risk and task progress, the active task's estimate, phase and auto-mode status, and a checklist of the current slice's tasks.
+
+### Fixed
+- **Codex models no longer reply as one unformatted block** — GPT-5 Codex variants are tuned for terminal output and skip markdown unless asked, so their replies rendered as a single wall of text. The extension now passes a short formatting instruction into the engine's system prompt (skipped automatically on engine builds that don't support it). Models that already format, like Claude, are unaffected.
+
 ### Changed
 - **Update checks no longer briefly freeze the editor** — resolving a GitHub token via `gh auth token` or `git credential-manager` ran synchronously on the extension host thread, so every extension in the window could stall for the duration of the subprocess (noticeably longer on Windows). Both lookups now run asynchronously.
 - **Faster `/ollama` status** — the version, loaded-models, and installed-models endpoints are fetched concurrently instead of one after another.

--- a/src/extension/rpc-client-addendum.test.ts
+++ b/src/extension/rpc-client-addendum.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { resolveFormattingAddendum, _resetAddendumCacheForTest } from "./rpc-client";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  _resetAddendumCacheForTest();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gsd-addendum-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeEngine(cliJsContent: string | null): string {
+  const entry = path.join(tmpDir, "loader.js");
+  fs.writeFileSync(entry, "// entry", "utf-8");
+  if (cliJsContent !== null) {
+    fs.writeFileSync(path.join(tmpDir, "cli.js"), cliJsContent, "utf-8");
+  }
+  return entry;
+}
+
+describe("resolveFormattingAddendum", () => {
+  it("returns a readable temp file when the engine supports the flag", () => {
+    const entry = makeEngine("parseCliArgs ... '--append-system-prompt' ...");
+    const result = resolveFormattingAddendum({ command: "node", args: [entry], useShell: false });
+    expect(result).not.toBeNull();
+    const content = fs.readFileSync(result!, "utf-8");
+    expect(content).toContain("GitHub-flavored markdown");
+  });
+
+  it("returns null when the engine cli.js lacks the flag", () => {
+    const entry = makeEngine("no such flag here");
+    expect(resolveFormattingAddendum({ command: "node", args: [entry], useShell: false })).toBeNull();
+  });
+
+  it("returns null when cli.js is missing", () => {
+    const entry = makeEngine(null);
+    expect(resolveFormattingAddendum({ command: "node", args: [entry], useShell: false })).toBeNull();
+  });
+
+  it("returns null for shell spawns", () => {
+    const entry = makeEngine("'--append-system-prompt'");
+    expect(resolveFormattingAddendum({ command: entry, args: [], useShell: true })).toBeNull();
+  });
+
+  it("returns null for bare command on PATH", () => {
+    expect(resolveFormattingAddendum({ command: "gsd", args: [], useShell: false })).toBeNull();
+  });
+
+  it("resolves a direct script command (unix symlink case)", () => {
+    const entry = makeEngine("'--append-system-prompt'");
+    // command points straight at the script, args empty — unix resolution shape
+    const result = resolveFormattingAddendum({ command: entry, args: [], useShell: false });
+    expect(result).not.toBeNull();
+  });
+
+  it("caches the support check per entry path", () => {
+    const entry = makeEngine("'--append-system-prompt'");
+    const first = resolveFormattingAddendum({ command: "node", args: [entry], useShell: false });
+    // Remove cli.js — cached verdict should still allow the addendum
+    fs.rmSync(path.join(tmpDir, "cli.js"));
+    const second = resolveFormattingAddendum({ command: "node", args: [entry], useShell: false });
+    expect(second).toBe(first);
+  });
+});

--- a/src/extension/rpc-client.ts
+++ b/src/extension/rpc-client.ts
@@ -2,6 +2,7 @@ import { ChildProcess, spawn, spawnSync } from "child_process";
 import { EventEmitter } from "events";
 import * as path from "path";
 import * as fs from "fs";
+import * as os from "os";
 import { resolveShellEnv, mergeShellEnv } from "./shell-env";
 import {
   MAX_STDOUT_BUFFER_BYTES,
@@ -259,6 +260,72 @@ function resolveGsdUnix(): { command: string; args: string[]; useShell: boolean 
   return { command: "gsd", args: [], useShell: false };
 }
 
+/**
+ * System-prompt addendum that makes terminal-tuned models (Codex) emit
+ * markdown instead of a single unformatted block. Kept short — it rides in
+ * every session's system prompt.
+ */
+const FORMATTING_ADDENDUM =
+  "Format chat responses in GitHub-flavored markdown: separate ideas into " +
+  "paragraphs with blank lines, and use lists, headers, and fenced code " +
+  "blocks where they aid readability. Never reply as one unbroken block of text.";
+
+// Cache: engine entry path -> whether its cli.js supports --append-system-prompt
+const addendumSupportCache = new Map<string, boolean>();
+let addendumFilePath: string | null = null;
+
+/**
+ * Return the path of a temp file holding FORMATTING_ADDENDUM, or null when it
+ * can't be safely passed: shell spawns re-split the command line (a path can
+ * contain spaces), and engine builds that predate --append-system-prompt
+ * exit(1) on the unknown flag. Support is detected by scanning the engine's
+ * cli.js (sibling of the resolved entry script) for the flag string.
+ */
+export function resolveFormattingAddendum(resolved: { command: string; args: string[]; useShell: boolean }): string | null {
+  if (resolved.useShell) return null;
+
+  // Windows: args[0] is the parsed .js entry. Unix: command is the gsd
+  // symlink — realpath it to land in the package's dist directory.
+  let entry = resolved.args[0];
+  if (!entry) {
+    try {
+      if (!path.isAbsolute(resolved.command)) return null; // bare "gsd" on PATH — can't locate cli.js
+      entry = fs.realpathSync(resolved.command);
+    } catch {
+      return null;
+    }
+  }
+
+  let supported = addendumSupportCache.get(entry);
+  if (supported === undefined) {
+    try {
+      const cliJs = path.join(path.dirname(entry), "cli.js");
+      supported = fs.existsSync(cliJs) && fs.readFileSync(cliJs, "utf-8").includes("--append-system-prompt");
+    } catch {
+      supported = false;
+    }
+    addendumSupportCache.set(entry, supported);
+  }
+  if (!supported) return null;
+
+  try {
+    if (!addendumFilePath || !fs.existsSync(addendumFilePath)) {
+      const p = path.join(os.tmpdir(), "gsd-vscode-format-prompt.md");
+      fs.writeFileSync(p, FORMATTING_ADDENDUM, "utf-8");
+      addendumFilePath = p;
+    }
+    return addendumFilePath;
+  } catch {
+    return null; // temp dir not writable — skip the addendum rather than fail spawn
+  }
+}
+
+/** Test-only: reset addendum caches. */
+export function _resetAddendumCacheForTest(): void {
+  addendumSupportCache.clear();
+  addendumFilePath = null;
+}
+
 export interface RpcEvent {
   type: string;
   [key: string]: unknown;
@@ -346,6 +413,18 @@ export class GsdRpcClient extends EventEmitter {
 
     if (options.sessionDir) {
       args.push("--session-dir", options.sessionDir);
+    }
+
+    // Response-formatting addendum for the engine's system prompt. Some models
+    // (GPT-5 Codex variants in particular) are tuned for terminal output and
+    // stream replies as one unformatted block unless the harness asks for
+    // markdown; models that already format treat this as a no-op. Passed as a
+    // file path because a literal sentence would be word-split when the spawn
+    // falls back to shell: true. Skipped when the engine build predates the
+    // flag — an unknown flag makes gsd-pi exit(1) before the RPC loop starts.
+    const addendumPath = resolveFormattingAddendum(resolved);
+    if (addendumPath) {
+      args.push("--append-system-prompt", addendumPath);
     }
 
     const env = mergeShellEnv(

--- a/src/extension/rpc-client.ts
+++ b/src/extension/rpc-client.ts
@@ -310,8 +310,12 @@ export function resolveFormattingAddendum(resolved: { command: string; args: str
 
   try {
     if (!addendumFilePath || !fs.existsSync(addendumFilePath)) {
-      const p = path.join(os.tmpdir(), "gsd-vscode-format-prompt.md");
-      fs.writeFileSync(p, FORMATTING_ADDENDUM, "utf-8");
+      // Private per-process temp dir + exclusive create with owner-only perms,
+      // so another local process can't pre-plant a symlink or swap the content
+      // before the engine reads it as its system prompt.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gsd-vscode-"));
+      const p = path.join(dir, "format-prompt.md");
+      fs.writeFileSync(p, FORMATTING_ADDENDUM, { encoding: "utf-8", flag: "wx", mode: 0o600 });
       addendumFilePath = p;
     }
     return addendumFilePath;

--- a/src/webview/__tests__/workflow-hover.test.ts
+++ b/src/webview/__tests__/workflow-hover.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as workflowHover from "../workflow-hover";
+import type { WorkflowState, DashboardData } from "../../shared/types";
+
+function makeState(overrides: Partial<WorkflowState> = {}): WorkflowState {
+  return {
+    milestone: { id: "M004", title: "Telegram Sync" },
+    slice: { id: "S02", title: "Bridge wiring" },
+    task: { id: "T03", title: "Wire polling loop" },
+    phase: "executing",
+    autoMode: null,
+    ...overrides,
+  };
+}
+
+function makeDashboard(overrides: Partial<DashboardData> = {}): DashboardData {
+  return {
+    hasProject: true,
+    hasMilestone: true,
+    milestone: { id: "M004", title: "Telegram Sync" },
+    slice: { id: "S02", title: "Bridge wiring" },
+    task: { id: "T03", title: "Wire polling loop" },
+    phase: "executing",
+    slices: [
+      {
+        id: "S02",
+        title: "Bridge wiring",
+        done: false,
+        risk: "high",
+        active: true,
+        tasks: [
+          { id: "T01", title: "Scaffold bridge", done: true, active: false, estimate: "30m" },
+          { id: "T02", title: "Session map", done: true, active: false },
+          { id: "T03", title: "Wire polling loop", done: false, active: true, estimate: "1h" },
+          { id: "T04", title: "Error handling", done: false, active: false },
+        ],
+      },
+    ],
+    milestoneRegistry: [
+      { id: "M001", title: "Core", done: true, active: false },
+      { id: "M004", title: "Telegram Sync", done: false, active: true },
+      { id: "M005", title: "Voice", done: false, active: false },
+    ],
+    progress: {
+      tasks: { done: 2, total: 4 },
+      slices: { done: 0, total: 1 },
+      milestones: { done: 1, total: 3 },
+    },
+    blockers: [],
+    nextAction: null,
+    ...overrides,
+  } as DashboardData;
+}
+
+let badge: HTMLElement;
+
+function hover(): void {
+  badge.dispatchEvent(new Event("mouseenter"));
+  vi.advanceTimersByTime(250);
+}
+
+function popover(): HTMLElement | null {
+  return document.getElementById("workflowPopover");
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.body.innerHTML = `<header><span id="workflowBadge" tabindex="0"></span></header>`;
+  badge = document.getElementById("workflowBadge")!;
+  workflowHover.init(badge);
+});
+
+afterEach(() => {
+  workflowHover._resetForTest();
+  vi.useRealTimers();
+});
+
+describe("workflow-hover", () => {
+  it("does not show a popover before any state has arrived", () => {
+    hover();
+    expect(popover()).toBeNull();
+  });
+
+  it("shows popover after hover delay once state is set", () => {
+    workflowHover.setWorkflowState(makeState());
+    badge.dispatchEvent(new Event("mouseenter"));
+    expect(popover()).toBeNull(); // not yet — delay pending
+    vi.advanceTimersByTime(250);
+    expect(popover()).not.toBeNull();
+  });
+
+  it("renders milestone, slice, and task titles from workflow state", () => {
+    workflowHover.setWorkflowState(makeState());
+    hover();
+    const text = popover()!.textContent!;
+    expect(text).toContain("M004 — Telegram Sync");
+    expect(text).toContain("S02 — Bridge wiring");
+    expect(text).toContain("T03 — Wire polling loop");
+    expect(text).toContain("Executing");
+  });
+
+  it("enriches with dashboard data: registry position, risk, task progress, estimate", () => {
+    workflowHover.setWorkflowState(makeState());
+    workflowHover.setDashboardData(makeDashboard());
+    hover();
+    const text = popover()!.textContent!;
+    expect(text).toContain("2 of 3 milestones");
+    expect(text).toContain("risk: high");
+    expect(text).toContain("2/4 tasks done");
+    expect(text).toContain("est: 1h");
+  });
+
+  it("renders the active slice's task checklist with done/active markers", () => {
+    workflowHover.setWorkflowState(makeState());
+    workflowHover.setDashboardData(makeDashboard());
+    hover();
+    const items = popover()!.querySelectorAll(".gsd-wf-pop-task");
+    expect(items.length).toBe(4);
+    expect(items[0].classList.contains("done")).toBe(true);
+    expect(items[2].classList.contains("active")).toBe(true);
+    expect(items[2].textContent).toContain("T03: Wire polling loop");
+  });
+
+  it("truncates long checklists with a +N more row", () => {
+    const dash = makeDashboard();
+    dash.slices[0].tasks = Array.from({ length: 11 }, (_, i) => ({
+      id: `T${i + 1}`, title: `Task ${i + 1}`, done: false, active: false,
+    }));
+    workflowHover.setWorkflowState(makeState());
+    workflowHover.setDashboardData(dash);
+    hover();
+    const items = popover()!.querySelectorAll(".gsd-wf-pop-task");
+    expect(items.length).toBe(9); // 8 tasks + "more" row
+    expect(items[8].textContent).toContain("+3 more");
+  });
+
+  it("shows self-directed message when workflow state is null", () => {
+    workflowHover.setWorkflowState(null);
+    hover();
+    expect(popover()!.textContent).toContain("Self-directed");
+  });
+
+  it("shows auto-mode status", () => {
+    workflowHover.setWorkflowState(makeState({ autoMode: "auto" }));
+    hover();
+    expect(popover()!.textContent).toContain("Auto-executing");
+  });
+
+  it("hides on mouseleave after the hide delay", () => {
+    workflowHover.setWorkflowState(makeState());
+    hover();
+    expect(popover()).not.toBeNull();
+    badge.dispatchEvent(new Event("mouseleave"));
+    vi.advanceTimersByTime(200);
+    expect(popover()).toBeNull();
+  });
+
+  it("cancels pending show when the pointer leaves before the delay", () => {
+    workflowHover.setWorkflowState(makeState());
+    badge.dispatchEvent(new Event("mouseenter"));
+    badge.dispatchEvent(new Event("mouseleave"));
+    vi.advanceTimersByTime(500);
+    expect(popover()).toBeNull();
+  });
+
+  it("shows immediately on keyboard focus and hides on blur", () => {
+    workflowHover.setWorkflowState(makeState());
+    badge.dispatchEvent(new Event("focus"));
+    expect(popover()).not.toBeNull();
+    expect(badge.getAttribute("aria-describedby")).toBe("workflowPopover");
+    badge.dispatchEvent(new Event("blur"));
+    expect(popover()).toBeNull();
+    expect(badge.hasAttribute("aria-describedby")).toBe(false);
+  });
+
+  it("hides on Escape", () => {
+    workflowHover.setWorkflowState(makeState());
+    badge.dispatchEvent(new Event("focus"));
+    expect(popover()).not.toBeNull();
+    badge.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(popover()).toBeNull();
+  });
+
+  it("re-renders an open popover when new state arrives", () => {
+    workflowHover.setWorkflowState(makeState());
+    hover();
+    expect(popover()!.textContent).toContain("T03");
+    workflowHover.setWorkflowState(makeState({ task: { id: "T04", title: "Error handling" } }));
+    expect(popover()!.textContent).toContain("T04 — Error handling");
+  });
+
+  it("renders titles as text, not HTML", () => {
+    workflowHover.setWorkflowState(makeState({
+      milestone: { id: "M001", title: "<img src=x onerror=alert(1)>" },
+      slice: null,
+      task: null,
+    }));
+    hover();
+    expect(popover()!.querySelector("img")).toBeNull();
+    expect(popover()!.textContent).toContain("<img src=x onerror=alert(1)>");
+  });
+});

--- a/src/webview/__tests__/workflow-hover.test.ts
+++ b/src/webview/__tests__/workflow-hover.test.ts
@@ -212,6 +212,20 @@ describe("workflow-hover", () => {
     expect(popover()!.textContent).toContain("T04 — Error handling");
   });
 
+  it("falls back to the dashboard milestone title when state and registry lack one", () => {
+    workflowHover.setWorkflowState(makeState({ milestone: { id: "M004", title: "" } }));
+    workflowHover.setDashboardData(makeDashboard({ milestoneRegistry: [] }));
+    hover();
+    expect(popover()!.textContent).toContain("M004 — Telegram Sync");
+  });
+
+  it("falls back to the dashboard task title when state and slice tasks lack one", () => {
+    workflowHover.setWorkflowState(makeState({ task: { id: "T03", title: "" } }));
+    workflowHover.setDashboardData(makeDashboard({ slices: [] }));
+    hover();
+    expect(popover()!.textContent).toContain("T03 — Wire polling loop");
+  });
+
   it("renders titles as text, not HTML", () => {
     workflowHover.setWorkflowState(makeState({
       milestone: { id: "M001", title: "<img src=x onerror=alert(1)>" },

--- a/src/webview/__tests__/workflow-hover.test.ts
+++ b/src/webview/__tests__/workflow-hover.test.ts
@@ -182,6 +182,28 @@ describe("workflow-hover", () => {
     expect(popover()).toBeNull();
   });
 
+  it("stays open while the badge keeps keyboard focus after the pointer leaves", () => {
+    workflowHover.setWorkflowState(makeState());
+    badge.focus();
+    badge.dispatchEvent(new Event("focus"));
+    expect(popover()).not.toBeNull();
+    badge.dispatchEvent(new Event("mouseenter"));
+    badge.dispatchEvent(new Event("mouseleave"));
+    vi.advanceTimersByTime(500);
+    expect(popover()).not.toBeNull();
+  });
+
+  it("focus during a pending hide delay cancels the hide", () => {
+    workflowHover.setWorkflowState(makeState());
+    hover();
+    badge.dispatchEvent(new Event("mouseleave"));
+    vi.advanceTimersByTime(50); // hide timer pending (150ms)
+    badge.focus();
+    badge.dispatchEvent(new Event("focus"));
+    vi.advanceTimersByTime(500);
+    expect(popover()).not.toBeNull();
+  });
+
   it("re-renders an open popover when new state arrives", () => {
     workflowHover.setWorkflowState(makeState());
     hover();

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -49,6 +49,7 @@ import * as thinkingPicker from "./thinking-picker";
 import * as sessionHistory from "./session-history";
 import * as uiDialogs from "./ui-dialogs";
 import * as toasts from "./toasts";
+import * as workflowHover from "./workflow-hover";
 import * as renderer from "./renderer";
 import * as dashboard from "./dashboard";
 import * as autoProgressWidget from "./auto-progress";
@@ -82,7 +83,7 @@ root.innerHTML = `
         <span class="gsd-title">Rokket GSD</span>
         <span class="gsd-header-version" id="headerVersion" title="View changelog" role="button" tabindex="0" aria-label="View changelog"></span>
       </div>
-      <span class="gsd-workflow-badge gsd-hidden" id="workflowBadge" title="GSD workflow state" role="status" aria-label="Workflow state"></span>
+      <span class="gsd-workflow-badge gsd-hidden" id="workflowBadge" role="status" tabindex="0" aria-label="Workflow state"></span>
       <div class="gsd-header-info" role="status" aria-label="Session info">
         <span class="gsd-model-badge gsd-hidden" id="modelBadge" title="Model" aria-label="Current model"></span>
         <span class="gsd-thinking-badge gsd-hidden" id="thinkingBadge" title="Thinking level" aria-label="Thinking level"></span>
@@ -1053,6 +1054,7 @@ uiDialogs.init({
 });
 
 toasts.init(document.getElementById("toastContainer")!);
+workflowHover.init(document.getElementById("workflowBadge")!);
 
 renderer.init({
   messagesContainer,

--- a/src/webview/message-handler.ts
+++ b/src/webview/message-handler.ts
@@ -24,6 +24,7 @@ import {
 } from "./state";
 import * as renderer from "./renderer";
 import * as sessionHistory from "./session-history";
+import * as workflowHover from "./workflow-hover";
 import * as slashMenu from "./slash-menu";
 import * as modelPicker from "./model-picker";
 import * as thinkingPicker from "./thinking-picker";
@@ -421,10 +422,12 @@ function handleMessage(event: MessageEvent): void {
 
     case "workflow_state": {
       updateWorkflowBadge(msg.state);
+      workflowHover.setWorkflowState(msg.state);
       break;
     }
 
     case "dashboard_data": {
+      workflowHover.setDashboardData(msg.data);
       // If visualizer is open, only feed it — don't render inline dashboard
       if (visualizer.isVisible()) {
         visualizer.updateData(msg.data);

--- a/src/webview/styles/layout.css
+++ b/src/webview/styles/layout.css
@@ -24,6 +24,7 @@
   background: var(--gsd-header-bg);
   min-height: 46px;
   flex-wrap: wrap;
+  position: relative;
 }
 
 .gsd-header-brand {
@@ -111,6 +112,94 @@
 .gsd-workflow-badge.complete {
   background: var(--gsd-badge-auto-bg);
   color: var(--gsd-badge-auto-fg);
+}
+
+/* Rich workflow-state popover shown on badge hover/focus */
+.gsd-workflow-popover {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 12px;
+  right: 12px;
+  max-width: 420px;
+  z-index: 60;
+  padding: 10px 12px;
+  border-radius: var(--gsd-radius-md);
+  background: var(--gsd-color-bg-secondary, var(--gsd-header-bg));
+  border: var(--gsd-border-width) solid var(--gsd-header-border);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  font-size: var(--gsd-font-size-base);
+  line-height: 1.45;
+}
+
+.gsd-wf-pop-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.gsd-wf-pop-label {
+  flex-shrink: 0;
+  width: 72px;
+  font-weight: var(--gsd-font-weight-medium);
+  color: var(--gsd-color-text-muted, inherit);
+  opacity: 0.75;
+}
+
+.gsd-wf-pop-value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.gsd-wf-pop-meta {
+  margin-left: 6px;
+  font-size: var(--gsd-font-size-sm, 11px);
+  opacity: 0.7;
+  white-space: nowrap;
+}
+
+.gsd-wf-pop-tasks {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 6px 0 0;
+  border-top: var(--gsd-border-width) solid var(--gsd-header-border);
+}
+
+.gsd-wf-pop-task {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 1px 0;
+}
+
+.gsd-wf-pop-task.done {
+  opacity: 0.6;
+}
+
+.gsd-wf-pop-task.active .gsd-wf-pop-task-title {
+  font-weight: var(--gsd-font-weight-medium);
+}
+
+.gsd-wf-pop-task.more {
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.gsd-wf-pop-task-mark {
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+}
+
+.gsd-wf-pop-task-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gsd-wf-pop-empty {
+  opacity: 0.7;
 }
 
 .gsd-header-info {

--- a/src/webview/workflow-hover.ts
+++ b/src/webview/workflow-hover.ts
@@ -1,0 +1,245 @@
+// ============================================================
+// Workflow Hover — rich popover for the header workflow badge.
+// Shows milestone/slice/task titles, progress, risk, estimates,
+// and the current slice's task checklist on hover or keyboard focus.
+// ============================================================
+
+import type { WorkflowState, DashboardData } from "../shared/types";
+
+const SHOW_DELAY_MS = 200;
+const HIDE_DELAY_MS = 150;
+const MAX_CHECKLIST_TASKS = 8;
+
+let badgeEl: HTMLElement | null = null;
+let popoverEl: HTMLElement | null = null;
+let showTimer: ReturnType<typeof setTimeout> | null = null;
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+let currentState: WorkflowState | null = null;
+let currentDashboard: DashboardData | null = null;
+let hasState = false;
+
+const PHASE_LABELS: Record<string, string> = {
+  "pre-planning": "Pre-planning",
+  "discussing": "Discussing",
+  "researching": "Researching",
+  "planning": "Planning",
+  "executing": "Executing",
+  "verifying": "Verifying",
+  "summarizing": "Summarizing",
+  "advancing": "Advancing",
+  "completing-milestone": "Completing milestone",
+  "replanning-slice": "Replanning slice",
+  "complete": "Complete",
+  "paused": "Paused",
+  "blocked": "Blocked",
+};
+
+const AUTO_MODE_LABELS: Record<string, string> = {
+  auto: "Auto-executing",
+  next: "Auto (next unit)",
+  paused: "Auto-mode paused",
+};
+
+/** Wire hover/focus listeners onto the workflow badge. */
+export function init(badge: HTMLElement): void {
+  badgeEl = badge;
+  badge.addEventListener("mouseenter", scheduleShow);
+  badge.addEventListener("mouseleave", scheduleHide);
+  badge.addEventListener("focus", () => show());
+  badge.addEventListener("blur", () => hide());
+  badge.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") hide();
+  });
+}
+
+/** Latest workflow state from the extension (STATE.md parse). */
+export function setWorkflowState(wf: WorkflowState | null): void {
+  currentState = wf;
+  hasState = true;
+  if (popoverEl) renderInto(popoverEl);
+}
+
+/** Latest dashboard payload — provides slices, tasks, and registry detail. */
+export function setDashboardData(data: DashboardData | null): void {
+  currentDashboard = data;
+  if (popoverEl) renderInto(popoverEl);
+}
+
+function scheduleShow(): void {
+  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+  if (popoverEl || showTimer) return;
+  showTimer = setTimeout(() => { showTimer = null; show(); }, SHOW_DELAY_MS);
+}
+
+function scheduleHide(): void {
+  if (showTimer) { clearTimeout(showTimer); showTimer = null; }
+  if (!popoverEl || hideTimer) return;
+  hideTimer = setTimeout(() => { hideTimer = null; hide(); }, HIDE_DELAY_MS);
+}
+
+function show(): void {
+  if (!badgeEl || popoverEl) return;
+  // Nothing meaningful to show before any state has arrived
+  if (!hasState && !currentDashboard) return;
+
+  const pop = document.createElement("div");
+  pop.className = "gsd-workflow-popover";
+  pop.id = "workflowPopover";
+  pop.setAttribute("role", "tooltip");
+  renderInto(pop);
+
+  // Keep the popover open while the pointer is over it
+  pop.addEventListener("mouseenter", () => {
+    if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+  });
+  pop.addEventListener("mouseleave", scheduleHide);
+
+  badgeEl.setAttribute("aria-describedby", "workflowPopover");
+  // Anchor to the badge's positioned wrapper (header) so it tracks layout
+  badgeEl.insertAdjacentElement("afterend", pop);
+  popoverEl = pop;
+}
+
+function hide(): void {
+  if (showTimer) { clearTimeout(showTimer); showTimer = null; }
+  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+  if (popoverEl) {
+    popoverEl.remove();
+    popoverEl = null;
+  }
+  badgeEl?.removeAttribute("aria-describedby");
+}
+
+// ── Rendering ────────────────────────────────────────────────
+
+function row(label: string, ...children: (HTMLElement | string)[]): HTMLElement {
+  const r = document.createElement("div");
+  r.className = "gsd-wf-pop-row";
+  const l = document.createElement("span");
+  l.className = "gsd-wf-pop-label";
+  l.textContent = label;
+  r.appendChild(l);
+  const v = document.createElement("span");
+  v.className = "gsd-wf-pop-value";
+  for (const c of children) {
+    if (typeof c === "string") v.appendChild(document.createTextNode(c));
+    else v.appendChild(c);
+  }
+  r.appendChild(v);
+  return r;
+}
+
+function meta(text: string): HTMLElement {
+  const s = document.createElement("span");
+  s.className = "gsd-wf-pop-meta";
+  s.textContent = text;
+  return s;
+}
+
+function refText(id: string, title: string): string {
+  return title ? `${id} — ${title}` : id;
+}
+
+function renderInto(pop: HTMLElement): void {
+  pop.textContent = "";
+  const wf = currentState;
+  const d = currentDashboard;
+
+  if (!wf) {
+    const p = document.createElement("div");
+    p.className = "gsd-wf-pop-empty";
+    p.textContent = "Self-directed — no active GSD workflow.";
+    pop.appendChild(p);
+    return;
+  }
+
+  // Milestone: prefer dashboard title (same source, but registry adds position)
+  if (wf.milestone) {
+    const extras: HTMLElement[] = [];
+    const registry = d?.milestoneRegistry ?? [];
+    const idx = registry.findIndex((m) => m.id === wf.milestone!.id);
+    if (idx >= 0) extras.push(meta(`${idx + 1} of ${registry.length} milestones`));
+    const title = wf.milestone.title || registry[idx]?.title || "";
+    pop.appendChild(row("Milestone", refText(wf.milestone.id, title), ...extras));
+  }
+
+  // Slice: title, risk, task progress
+  const dashSlice = wf.slice ? (d?.slices ?? []).find((s) => s.id === wf.slice!.id) : undefined;
+  if (wf.slice) {
+    const extras: HTMLElement[] = [];
+    if (dashSlice?.risk && dashSlice.risk !== "low") extras.push(meta(`risk: ${dashSlice.risk}`));
+    const prog = dashSlice?.taskProgress
+      ?? (dashSlice ? { done: dashSlice.tasks.filter((t) => t.done).length, total: dashSlice.tasks.length } : null);
+    if (prog && prog.total > 0) extras.push(meta(`${prog.done}/${prog.total} tasks done`));
+    const title = wf.slice.title || dashSlice?.title || "";
+    pop.appendChild(row("Slice", refText(wf.slice.id, title), ...extras));
+  }
+
+  // Task: title + estimate
+  if (wf.task) {
+    const extras: HTMLElement[] = [];
+    const dashTask = dashSlice?.tasks.find((t) => t.id === wf.task!.id);
+    if (dashTask?.estimate) extras.push(meta(`est: ${dashTask.estimate}`));
+    const title = wf.task.title || dashTask?.title || "";
+    pop.appendChild(row("Task", refText(wf.task.id, title), ...extras));
+  }
+
+  // Phase + auto-mode status
+  const statusParts: string[] = [];
+  const phaseLabel = PHASE_LABELS[wf.phase] || (wf.phase !== "unknown" ? wf.phase : "");
+  if (phaseLabel) statusParts.push(phaseLabel);
+  if (wf.autoMode && AUTO_MODE_LABELS[wf.autoMode]) statusParts.push(AUTO_MODE_LABELS[wf.autoMode]);
+  if (statusParts.length > 0) {
+    pop.appendChild(row("Status", statusParts.join(" · ")));
+  }
+
+  // Mini checklist of the active slice's tasks
+  if (dashSlice && dashSlice.tasks.length > 0) {
+    const list = document.createElement("ul");
+    list.className = "gsd-wf-pop-tasks";
+    const tasks = dashSlice.tasks.slice(0, MAX_CHECKLIST_TASKS);
+    for (const t of tasks) {
+      const li = document.createElement("li");
+      li.className = "gsd-wf-pop-task" + (t.done ? " done" : "") + (t.id === wf.task?.id ? " active" : "");
+      const mark = document.createElement("span");
+      mark.className = "gsd-wf-pop-task-mark";
+      mark.textContent = t.done ? "✓" : t.id === wf.task?.id ? "▸" : "○";
+      li.appendChild(mark);
+      const label = document.createElement("span");
+      label.className = "gsd-wf-pop-task-title";
+      label.textContent = `${t.id}: ${t.title}`;
+      li.appendChild(label);
+      list.appendChild(li);
+    }
+    if (dashSlice.tasks.length > MAX_CHECKLIST_TASKS) {
+      const li = document.createElement("li");
+      li.className = "gsd-wf-pop-task more";
+      li.textContent = `+${dashSlice.tasks.length - MAX_CHECKLIST_TASKS} more`;
+      list.appendChild(li);
+    }
+    pop.appendChild(list);
+  }
+
+  // Next pending task (after the active one) when not shown in checklist context
+  if (dashSlice && !wf.task) {
+    const next = dashSlice.tasks.find((t) => !t.done);
+    if (next) pop.appendChild(row("Next", refText(next.id, next.title)));
+  }
+
+  if (pop.childElementCount === 0) {
+    const p = document.createElement("div");
+    p.className = "gsd-wf-pop-empty";
+    p.textContent = "No active workflow details.";
+    pop.appendChild(p);
+  }
+}
+
+/** Test-only: reset module state between tests. */
+export function _resetForTest(): void {
+  hide();
+  badgeEl = null;
+  currentState = null;
+  currentDashboard = null;
+  hasState = false;
+}

--- a/src/webview/workflow-hover.ts
+++ b/src/webview/workflow-hover.ts
@@ -164,7 +164,9 @@ function renderInto(pop: HTMLElement): void {
     const registry = d?.milestoneRegistry ?? [];
     const idx = registry.findIndex((m) => m.id === wf.milestone!.id);
     if (idx >= 0) extras.push(meta(`${idx + 1} of ${registry.length} milestones`));
-    const title = wf.milestone.title || registry[idx]?.title || "";
+    const dashMilestoneTitle =
+      d?.milestone?.id === wf.milestone.id ? d.milestone.title : "";
+    const title = wf.milestone.title || registry[idx]?.title || dashMilestoneTitle || "";
     pop.appendChild(row("Milestone", refText(wf.milestone.id, title), ...extras));
   }
 
@@ -185,7 +187,8 @@ function renderInto(pop: HTMLElement): void {
     const extras: HTMLElement[] = [];
     const dashTask = dashSlice?.tasks.find((t) => t.id === wf.task!.id);
     if (dashTask?.estimate) extras.push(meta(`est: ${dashTask.estimate}`));
-    const title = wf.task.title || dashTask?.title || "";
+    const dashTaskTitle = d?.task?.id === wf.task.id ? d.task.title : "";
+    const title = wf.task.title || dashTask?.title || dashTaskTitle || "";
     pop.appendChild(row("Task", refText(wf.task.id, title), ...extras));
   }
 

--- a/src/webview/workflow-hover.ts
+++ b/src/webview/workflow-hover.ts
@@ -74,11 +74,15 @@ function scheduleShow(): void {
 
 function scheduleHide(): void {
   if (showTimer) { clearTimeout(showTimer); showTimer = null; }
+  // Keyboard focus keeps the popover open; blur/Escape close it instead
+  if (badgeEl && document.activeElement === badgeEl) return;
   if (!popoverEl || hideTimer) return;
   hideTimer = setTimeout(() => { hideTimer = null; hide(); }, HIDE_DELAY_MS);
 }
 
 function show(): void {
+  // Cancel a pending hide so focus during the hide delay keeps the popover
+  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
   if (!badgeEl || popoverEl) return;
   // Nothing meaningful to show before any state has arrived
   if (!hasState && !currentDashboard) return;


### PR DESCRIPTION
## Summary

Two changes:

**Rich workflow-state popover.** Hovering or keyboard-focusing the GSD workflow badge in the header now opens a detail panel instead of the old static tooltip. It shows milestone, slice, and task titles (parsed from STATE.md but never previously displayed), the milestone's position in the registry, slice risk and task progress, the active task's estimate, phase and auto-mode status, and a checklist of the current slice's tasks. All data comes from the existing workflow_state and dashboard_data messages - no new parsing or polling. Built with DOM APIs (no innerHTML for file-sourced text), 200ms show delay, focus/blur and Escape support for accessibility.

**Codex replies no longer render as one unformatted block.** GPT-5 Codex variants are tuned for terminal output and skip markdown unless the harness asks for it. The RPC client now injects a short formatting instruction through gsd-pi's --append-system-prompt at spawn. Passed as a temp-file path (shell spawns would word-split literal text) and gated on the engine build actually supporting the flag, since older engines exit(1) on unknown flags. Models that already format, like Claude, are unaffected.

## Testing

- 21 new unit tests (14 popover, 7 addendum resolver)
- Full suite: 1431 tests / 74 files green
- tsc --noEmit and eslint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive workflow-state popover to the header badge, showing milestone, task, status, risk, progress, checklist and next-task details.
  * Added keyboard accessibility, delayed hover behaviour and Escape-to-dismiss support.
  * Improved GPT-5 Codex response formatting where supported, with graceful handling for incompatible versions.
* **Documentation**
  * Updated the unreleased changelog to document the workflow popover and formatting improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->